### PR TITLE
Adding slf4j-nop dependency

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -34,6 +34,7 @@ dependencies {
     compile 'com.google.guava:guava:18.0'
     compile 'org.apache.commons:commons-lang3:3.1'
     compile 'org.parboiled:parboiled-java:1.1.7'
+    compile 'org.slf4j:slf4j-nop:1.7.12'
     compile 'org.slf4j:slf4j-api:1.7.12'
     compile 'com.googlecode.concurrentlinkedhashmap:concurrentlinkedhashmap-lru:1.4.2'
 


### PR DESCRIPTION
It will get rid of the slf4j warning message jtwig/jtwig#314
