### PR TITLE
fix for windows absolute paths that start from disk letter

### DIFF
--- a/src/main/java/org/jtwig/resource/resolver/path/RelativePathResolver.java
+++ b/src/main/java/org/jtwig/resource/resolver/path/RelativePathResolver.java
@@ -22,7 +22,11 @@ public class RelativePathResolver {
     public String resolve(String parent, String child) {
         File newFile = new File(new File(parent).getParentFile(), child);
         try {
-            return newFile.getCanonicalPath();
+            String path = newFile.getCanonicalPath();
+            if (path.charAt(1) == ':')
+                return path.replaceFirst("^.:", "");
+            else
+                return path;
         } catch (IOException e) {
             throw new ResourceException(String.format("Canonical path ('%s', '%s') = '%s' is invalid", parent, child, newFile.getPath()));
         }


### PR DESCRIPTION
There is a painful bug in your reelative path resolver - when I launch it on windows, absolute path contains disk letter and that breaks everything(for example, \views\error..\baseTemplate.html turns into  C:\views\reports\reportTemplate.html instead of \views\reports\reportTemplate.html). My patch fixes that for developers on windows. Plz merge it into your master branch.
