### PR TITLE
MapPropertyResolver sould check if key exist before returning value

### DIFF
--- a/src/main/java/org/jtwig/property/resolver/MapPropertyResolver.java
+++ b/src/main/java/org/jtwig/property/resolver/MapPropertyResolver.java
@@ -12,6 +12,10 @@ public class MapPropertyResolver implements PropertyResolver {
         if (request.getContext() == null) return Optional.absent();
         if (!(request.getContext() instanceof Map)) return Optional.absent();
 
-        return Optional.of(new Value(((Map) request.getContext()).get(request.getPropertyName().get())));
+        if(((Map) request.getContext()).containsKey(request.getPropertyName().get())){
+            return Optional.of(new Value(((Map) request.getContext()).get(request.getPropertyName().get())));
+        }else{
+            return Optional.absent();
+        }
     }
 }


### PR DESCRIPTION
MapPropertyResolver sould check if key exist before returning value.

See test case attached in the zip.

[TestCase.zip](https://github.com/jtwig/jtwig-core/files/885335/TestCase.zip)