### PR TITLE
members after square bracket notation

### DIFF
--- a/src/main/java/org/jtwig/parser/parboiled/ParserContext.java
+++ b/src/main/java/org/jtwig/parser/parboiled/ParserContext.java
@@ -59,6 +59,7 @@ public class ParserContext {
         createParser(TestOperationExpressionParser.class, context);
         createParser(UnaryOperationExpressionParser.class, context);
         createParser(BinaryOperationExpressionParser.class, context, binaryOperators);
+        createParser(BinaryOperationSuffixExpressionParser.class, context, binaryOperators);
         createParser(TernaryOperationExpressionParser.class, context);
         createParser(PrimaryExpressionParser.class, context);
         createParser(SimpleExpressionParser.class, context);

--- a/src/main/java/org/jtwig/parser/parboiled/ParserContext.java
+++ b/src/main/java/org/jtwig/parser/parboiled/ParserContext.java
@@ -58,7 +58,7 @@ public class ParserContext {
         createParser(FunctionExpressionParser.class, context);
         createParser(TestOperationExpressionParser.class, context);
         createParser(UnaryOperationExpressionParser.class, context);
-        createParser(BinaryOperationExpressionParser.class, context, binaryOperators);
+        createParser(BinaryOperationExpressionParser.class, context);
         createParser(BinaryOperationSuffixExpressionParser.class, context, binaryOperators);
         createParser(TernaryOperationExpressionParser.class, context);
         createParser(PrimaryExpressionParser.class, context);

--- a/src/main/java/org/jtwig/parser/parboiled/expression/BinaryOperationExpressionParser.java
+++ b/src/main/java/org/jtwig/parser/parboiled/expression/BinaryOperationExpressionParser.java
@@ -1,68 +1,19 @@
 package org.jtwig.parser.parboiled.expression;
 
-import com.google.common.base.Function;
-import com.google.common.collect.ImmutableListMultimap;
-import com.google.common.collect.Multimaps;
 import org.jtwig.model.expression.BinaryOperationExpression;
 import org.jtwig.parser.parboiled.ParserContext;
-import org.jtwig.parser.parboiled.base.PositionTrackerParser;
-import org.jtwig.parser.parboiled.base.SpacingParser;
-import org.jtwig.parser.parboiled.expression.operator.BinaryOperatorParser;
-import org.jtwig.render.expression.calculator.operation.binary.BinaryOperator;
 import org.parboiled.Rule;
 
-import java.util.ArrayList;
-import java.util.Collection;
-import java.util.Collections;
-import java.util.List;
-
 public class BinaryOperationExpressionParser extends ExpressionParser<BinaryOperationExpression> {
-    final Collection<BinaryOperator> operators;
-
-    public BinaryOperationExpressionParser(ParserContext context, Collection<BinaryOperator> operators) {
+    public BinaryOperationExpressionParser(ParserContext context) {
         super(BinaryOperationExpressionParser.class, context);
-        this.operators = operators;
     }
 
     @Override
     public Rule ExpressionRule() {
-        Rule initialExpression = parserContext().parser(PrimaryExpressionParser.class).ExpressionRule();
-        ImmutableListMultimap<Integer, BinaryOperator> index = Multimaps.index(operators, precedence());
-
-        List<Integer> integers = new ArrayList<>(index.keySet());
-        Collections.sort(integers);
-        for (Integer integer : integers) {
-            initialExpression = BinaryOperation(initialExpression, index.get(integer));
-        }
-        return initialExpression;
-    }
-
-    Function<BinaryOperator, Integer> precedence() {
-        return new Function<BinaryOperator, Integer>() {
-            @Override
-            public Integer apply(BinaryOperator input) {
-                return input.precedence();
-            }
-        };
-    }
-
-    Rule BinaryOperation(Rule expressionRule, List<BinaryOperator> operator) {
         return Sequence(
-                expressionRule,
-                parserContext().parser(SpacingParser.class).Spacing(),
-                ZeroOrMore(
-                        parserContext().parser(PositionTrackerParser.class).PushPosition(),
-                        parserContext().parser(BinaryOperatorParser.class).BinaryOperator(operator),
-                        parserContext().parser(SpacingParser.class).Spacing(),
-                        expressionRule,
-                        push(new BinaryOperationExpression(
-                                parserContext().parser(PositionTrackerParser.class).pop(2),
-                                pop(2),
-                                parserContext().parser(BinaryOperatorParser.class).pop(1),
-                                pop()
-                        ))
-                )
-
+                parserContext().parser(PrimaryExpressionParser.class).ExpressionRule(),
+                parserContext().parser(BinaryOperationSuffixExpressionParser.class).ExpressionRule()
         );
     }
 }

--- a/src/main/java/org/jtwig/parser/parboiled/expression/BinaryOperationSuffixExpressionParser.java
+++ b/src/main/java/org/jtwig/parser/parboiled/expression/BinaryOperationSuffixExpressionParser.java
@@ -48,13 +48,13 @@ public class BinaryOperationSuffixExpressionParser extends ExpressionParser<Bina
         };
     }
 
-    Rule BinaryOperation(Rule expressionRule, List<BinaryOperator> operator) {
+    Rule BinaryOperation(Rule expressionRule, List<BinaryOperator> operators) {
         if (expressionRule == null) {
             return Sequence(
                     parserContext().parser(SpacingParser.class).Spacing(),
                     ZeroOrMore(
                             parserContext().parser(PositionTrackerParser.class).PushPosition(),
-                            parserContext().parser(BinaryOperatorParser.class).BinaryOperator(operator),
+                            parserContext().parser(BinaryOperatorParser.class).BinaryOperator(operators),
                             parserContext().parser(SpacingParser.class).Spacing(),
                             parserContext().parser(PrimaryExpressionParser.class).ExpressionRule(),
                             push(new BinaryOperationExpression(
@@ -72,9 +72,12 @@ public class BinaryOperationSuffixExpressionParser extends ExpressionParser<Bina
                     parserContext().parser(SpacingParser.class).Spacing(),
                     ZeroOrMore(
                             parserContext().parser(PositionTrackerParser.class).PushPosition(),
-                            parserContext().parser(BinaryOperatorParser.class).BinaryOperator(operator),
+                            parserContext().parser(BinaryOperatorParser.class).BinaryOperator(operators),
                             parserContext().parser(SpacingParser.class).Spacing(),
-                            parserContext().parser(BinaryOperationExpressionParser.class).ExpressionRule(),
+                            Sequence(
+                                    parserContext().parser(PrimaryExpressionParser.class).ExpressionRule(),
+                                    expressionRule
+                            ),
                             push(new BinaryOperationExpression(
                                     parserContext().parser(PositionTrackerParser.class).pop(2),
                                     pop(2),

--- a/src/main/java/org/jtwig/parser/parboiled/expression/BinaryOperationSuffixExpressionParser.java
+++ b/src/main/java/org/jtwig/parser/parboiled/expression/BinaryOperationSuffixExpressionParser.java
@@ -52,16 +52,18 @@ public class BinaryOperationSuffixExpressionParser extends ExpressionParser<Bina
         if (expressionRule == null) {
             return Sequence(
                     parserContext().parser(SpacingParser.class).Spacing(),
-                    parserContext().parser(PositionTrackerParser.class).PushPosition(),
-                    parserContext().parser(BinaryOperatorParser.class).BinaryOperator(operator),
-                    parserContext().parser(SpacingParser.class).Spacing(),
-                    parserContext().parser(PrimaryExpressionParser.class).ExpressionRule(),
-                    push(new BinaryOperationExpression(
-                            parserContext().parser(PositionTrackerParser.class).pop(2),
-                            pop(2),
-                            parserContext().parser(BinaryOperatorParser.class).pop(1),
-                            pop()
-                    ))
+                    ZeroOrMore(
+                            parserContext().parser(PositionTrackerParser.class).PushPosition(),
+                            parserContext().parser(BinaryOperatorParser.class).BinaryOperator(operator),
+                            parserContext().parser(SpacingParser.class).Spacing(),
+                            parserContext().parser(PrimaryExpressionParser.class).ExpressionRule(),
+                            push(new BinaryOperationExpression(
+                                    parserContext().parser(PositionTrackerParser.class).pop(2),
+                                    pop(2),
+                                    parserContext().parser(BinaryOperatorParser.class).pop(1),
+                                    pop()
+                            ))
+                    )
             );
 
         } else {
@@ -72,7 +74,7 @@ public class BinaryOperationSuffixExpressionParser extends ExpressionParser<Bina
                             parserContext().parser(PositionTrackerParser.class).PushPosition(),
                             parserContext().parser(BinaryOperatorParser.class).BinaryOperator(operator),
                             parserContext().parser(SpacingParser.class).Spacing(),
-                            expressionRule,
+                            parserContext().parser(BinaryOperationExpressionParser.class).ExpressionRule(),
                             push(new BinaryOperationExpression(
                                     parserContext().parser(PositionTrackerParser.class).pop(2),
                                     pop(2),

--- a/src/main/java/org/jtwig/parser/parboiled/expression/BinaryOperationSuffixExpressionParser.java
+++ b/src/main/java/org/jtwig/parser/parboiled/expression/BinaryOperationSuffixExpressionParser.java
@@ -1,0 +1,68 @@
+package org.jtwig.parser.parboiled.expression;
+
+import com.google.common.base.Function;
+import com.google.common.collect.ImmutableListMultimap;
+import com.google.common.collect.Multimaps;
+import org.jtwig.model.expression.BinaryOperationExpression;
+import org.jtwig.parser.parboiled.ParserContext;
+import org.jtwig.parser.parboiled.base.PositionTrackerParser;
+import org.jtwig.parser.parboiled.base.SpacingParser;
+import org.jtwig.parser.parboiled.expression.operator.BinaryOperatorParser;
+import org.jtwig.render.expression.calculator.operation.binary.BinaryOperator;
+import org.parboiled.Rule;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
+
+public class BinaryOperationExpressionParser extends ExpressionParser<BinaryOperationExpression> {
+    final Collection<BinaryOperator> operators;
+
+    public BinaryOperationExpressionParser(ParserContext context, Collection<BinaryOperator> operators) {
+        super(BinaryOperationExpressionParser.class, context);
+        this.operators = operators;
+    }
+
+    @Override
+    public Rule ExpressionRule() {
+        Rule initialExpression = parserContext().parser(PrimaryExpressionParser.class).ExpressionRule();
+        ImmutableListMultimap<Integer, BinaryOperator> index = Multimaps.index(operators, precedence());
+
+        List<Integer> integers = new ArrayList<>(index.keySet());
+        Collections.sort(integers);
+        for (Integer integer : integers) {
+            initialExpression = BinaryOperation(initialExpression, index.get(integer));
+        }
+        return initialExpression;
+    }
+
+    Function<BinaryOperator, Integer> precedence() {
+        return new Function<BinaryOperator, Integer>() {
+            @Override
+            public Integer apply(BinaryOperator input) {
+                return input.precedence();
+            }
+        };
+    }
+
+    Rule BinaryOperation(Rule expressionRule, List<BinaryOperator> operator) {
+        return Sequence(
+                expressionRule,
+                parserContext().parser(SpacingParser.class).Spacing(),
+                ZeroOrMore(
+                        parserContext().parser(PositionTrackerParser.class).PushPosition(),
+                        parserContext().parser(BinaryOperatorParser.class).BinaryOperator(operator),
+                        parserContext().parser(SpacingParser.class).Spacing(),
+                        expressionRule,
+                        push(new BinaryOperationExpression(
+                                parserContext().parser(PositionTrackerParser.class).pop(2),
+                                pop(2),
+                                parserContext().parser(BinaryOperatorParser.class).pop(1),
+                                pop()
+                        ))
+                )
+
+        );
+    }
+}

--- a/src/main/java/org/jtwig/parser/parboiled/expression/BinaryOperationSuffixExpressionParser.java
+++ b/src/main/java/org/jtwig/parser/parboiled/expression/BinaryOperationSuffixExpressionParser.java
@@ -10,6 +10,7 @@ import org.jtwig.parser.parboiled.base.SpacingParser;
 import org.jtwig.parser.parboiled.expression.operator.BinaryOperatorParser;
 import org.jtwig.render.expression.calculator.operation.binary.BinaryOperator;
 import org.parboiled.Rule;
+import org.parboiled.annotations.Label;
 
 import java.util.ArrayList;
 import java.util.Collection;
@@ -25,6 +26,7 @@ public class BinaryOperationSuffixExpressionParser extends ExpressionParser<Bina
     }
 
     @Override
+    @Label("BinaryOperationSuffix Expression")
     public Rule ExpressionRule() {
         Rule initialExpression = null;
         ImmutableListMultimap<Integer, BinaryOperator> index = Multimaps.index(operators, precedence());

--- a/src/main/java/org/jtwig/parser/parboiled/expression/BinaryOperationSuffixExpressionParser.java
+++ b/src/main/java/org/jtwig/parser/parboiled/expression/BinaryOperationSuffixExpressionParser.java
@@ -28,7 +28,7 @@ public class BinaryOperationSuffixExpressionParser extends ExpressionParser<Bina
     @Override
     @Label("BinaryOperationSuffix Expression")
     public Rule ExpressionRule() {
-        Rule initialExpression = null;
+        Rule initialExpression = EMPTY;
         ImmutableListMultimap<Integer, BinaryOperator> index = Multimaps.index(operators, precedence());
 
         List<Integer> integers = new ArrayList<>(index.keySet());
@@ -49,44 +49,25 @@ public class BinaryOperationSuffixExpressionParser extends ExpressionParser<Bina
     }
 
     Rule BinaryOperation(Rule expressionRule, List<BinaryOperator> operators) {
-        if (expressionRule == null) {
-            return Sequence(
-                    parserContext().parser(SpacingParser.class).Spacing(),
-                    ZeroOrMore(
-                            parserContext().parser(PositionTrackerParser.class).PushPosition(),
-                            parserContext().parser(BinaryOperatorParser.class).BinaryOperator(operators),
-                            parserContext().parser(SpacingParser.class).Spacing(),
-                            parserContext().parser(PrimaryExpressionParser.class).ExpressionRule(),
-                            push(new BinaryOperationExpression(
-                                    parserContext().parser(PositionTrackerParser.class).pop(2),
-                                    pop(2),
-                                    parserContext().parser(BinaryOperatorParser.class).pop(1),
-                                    pop()
-                            ))
-                    )
-            );
+        return Sequence(
+                expressionRule,
+                parserContext().parser(SpacingParser.class).Spacing(),
+                ZeroOrMore(
+                        parserContext().parser(PositionTrackerParser.class).PushPosition(),
+                        parserContext().parser(BinaryOperatorParser.class).BinaryOperator(operators),
+                        parserContext().parser(SpacingParser.class).Spacing(),
+                        Sequence(
+                                parserContext().parser(PrimaryExpressionParser.class).ExpressionRule(),
+                                expressionRule
+                        ),
+                        push(new BinaryOperationExpression(
+                                parserContext().parser(PositionTrackerParser.class).pop(2),
+                                pop(2),
+                                parserContext().parser(BinaryOperatorParser.class).pop(1),
+                                pop()
+                        ))
+                )
 
-        } else {
-            return Sequence(
-                    expressionRule,
-                    parserContext().parser(SpacingParser.class).Spacing(),
-                    ZeroOrMore(
-                            parserContext().parser(PositionTrackerParser.class).PushPosition(),
-                            parserContext().parser(BinaryOperatorParser.class).BinaryOperator(operators),
-                            parserContext().parser(SpacingParser.class).Spacing(),
-                            Sequence(
-                                    parserContext().parser(PrimaryExpressionParser.class).ExpressionRule(),
-                                    expressionRule
-                            ),
-                            push(new BinaryOperationExpression(
-                                    parserContext().parser(PositionTrackerParser.class).pop(2),
-                                    pop(2),
-                                    parserContext().parser(BinaryOperatorParser.class).pop(1),
-                                    pop()
-                            ))
-                    )
-
-            );
-        }
+        );
     }
 }

--- a/src/main/java/org/jtwig/parser/parboiled/expression/MapSelectionExpressionParser.java
+++ b/src/main/java/org/jtwig/parser/parboiled/expression/MapSelectionExpressionParser.java
@@ -39,19 +39,17 @@ public class MapSelectionExpressionParser extends ExpressionParser<MapSelectionE
         PositionTrackerParser positionTrackerParser = parserContext().parser(PositionTrackerParser.class);
         SpacingParser spacingParser = parserContext().parser(SpacingParser.class);
 
-        return ZeroOrMore(
-                FirstOf(
-                        Sequence(
-                                positionTrackerParser.PushPosition(),
-                                String("["), spacingParser.Spacing(),
-                                binaryOrPrimaryExpressionParser.ExpressionRule(),
-                                spacingParser.Spacing(),
-                                String("]"),
+        return Sequence(
+                ZeroOrMore(
+                        positionTrackerParser.PushPosition(),
+                        String("["), spacingParser.Spacing(),
+                        binaryOrPrimaryExpressionParser.ExpressionRule(),
+                        spacingParser.Spacing(),
+                        String("]"),
 
-                                push(new MapSelectionExpression(positionTrackerParser.pop(1), binaryOrPrimaryExpressionParser.pop(1), binaryOrPrimaryExpressionParser.pop()))
-                        ),
-                        parserContext().parser(BinaryOperationSuffixExpressionParser.class).ExpressionRule()
-                )
+                        push(new MapSelectionExpression(positionTrackerParser.pop(1), binaryOrPrimaryExpressionParser.pop(1), binaryOrPrimaryExpressionParser.pop()))
+                ),
+                parserContext().parser(BinaryOperationSuffixExpressionParser.class).ExpressionRule()
         );
     }
 }

--- a/src/main/java/org/jtwig/parser/parboiled/expression/MapSelectionExpressionParser.java
+++ b/src/main/java/org/jtwig/parser/parboiled/expression/MapSelectionExpressionParser.java
@@ -28,7 +28,22 @@ public class MapSelectionExpressionParser extends ExpressionParser<MapSelectionE
                 spacingParser.Spacing(),
                 String("]"),
 
-                push(new MapSelectionExpression(positionTrackerParser.pop(2), binaryOrPrimaryExpressionParser.pop(1), binaryOrPrimaryExpressionParser.pop()))
+                push(new MapSelectionExpression(positionTrackerParser.pop(2), binaryOrPrimaryExpressionParser.pop(1), binaryOrPrimaryExpressionParser.pop())),
+
+                ZeroOrMore(
+                        FirstOf(
+                                Sequence(
+                                        positionTrackerParser.PushPosition(),
+                                        String("["), spacingParser.Spacing(),
+                                        binaryOrPrimaryExpressionParser.ExpressionRule(),
+                                        spacingParser.Spacing(),
+                                        String("]"),
+
+                                        push(new MapSelectionExpression(positionTrackerParser.pop(1), binaryOrPrimaryExpressionParser.pop(1), binaryOrPrimaryExpressionParser.pop()))
+                                ),
+                                parserContext().parser(BinaryOperationSuffixExpressionParser.class).ExpressionRule()
+                        )
+                )
         );
     }
 }

--- a/src/main/java/org/jtwig/parser/parboiled/expression/MapSelectionExpressionParser.java
+++ b/src/main/java/org/jtwig/parser/parboiled/expression/MapSelectionExpressionParser.java
@@ -5,6 +5,7 @@ import org.jtwig.parser.parboiled.ParserContext;
 import org.jtwig.parser.parboiled.base.PositionTrackerParser;
 import org.jtwig.parser.parboiled.base.SpacingParser;
 import org.parboiled.Rule;
+import org.parboiled.annotations.Label;
 
 public class MapSelectionExpressionParser extends ExpressionParser<MapSelectionExpression> {
     public MapSelectionExpressionParser(ParserContext context) {
@@ -12,21 +13,22 @@ public class MapSelectionExpressionParser extends ExpressionParser<MapSelectionE
     }
 
     @Override
+    @Label("MapSelection ExpressionParser")
     public Rule ExpressionRule() {
-        BinaryOrPrimaryExpressionParser anyExpressionParser = parserContext().parser(BinaryOrPrimaryExpressionParser.class);
+        BinaryOrPrimaryExpressionParser binaryOrPrimaryExpressionParser = parserContext().parser(BinaryOrPrimaryExpressionParser.class);
         PositionTrackerParser positionTrackerParser = parserContext().parser(PositionTrackerParser.class);
         SpacingParser spacingParser = parserContext().parser(SpacingParser.class);
 
         return Sequence(
                 positionTrackerParser.PushPosition(),
-                anyExpressionParser.ExpressionRule(),
+                binaryOrPrimaryExpressionParser.ExpressionRule(),
                 spacingParser.Spacing(),
                 String("["), spacingParser.Spacing(),
-                anyExpressionParser.ExpressionRule(),
+                binaryOrPrimaryExpressionParser.ExpressionRule(),
                 spacingParser.Spacing(),
                 String("]"),
 
-                push(new MapSelectionExpression(positionTrackerParser.pop(2), anyExpressionParser.pop(1), anyExpressionParser.pop()))
+                push(new MapSelectionExpression(positionTrackerParser.pop(2), binaryOrPrimaryExpressionParser.pop(1), binaryOrPrimaryExpressionParser.pop()))
         );
     }
 }

--- a/src/main/java/org/jtwig/parser/parboiled/expression/MapSelectionExpressionParser.java
+++ b/src/main/java/org/jtwig/parser/parboiled/expression/MapSelectionExpressionParser.java
@@ -13,7 +13,7 @@ public class MapSelectionExpressionParser extends ExpressionParser<MapSelectionE
     }
 
     @Override
-    @Label("MapSelection ExpressionParser")
+    @Label("MapSelection Expression")
     public Rule ExpressionRule() {
         BinaryOrPrimaryExpressionParser binaryOrPrimaryExpressionParser = parserContext().parser(BinaryOrPrimaryExpressionParser.class);
         PositionTrackerParser positionTrackerParser = parserContext().parser(PositionTrackerParser.class);
@@ -30,19 +30,27 @@ public class MapSelectionExpressionParser extends ExpressionParser<MapSelectionE
 
                 push(new MapSelectionExpression(positionTrackerParser.pop(2), binaryOrPrimaryExpressionParser.pop(1), binaryOrPrimaryExpressionParser.pop())),
 
-                ZeroOrMore(
-                        FirstOf(
-                                Sequence(
-                                        positionTrackerParser.PushPosition(),
-                                        String("["), spacingParser.Spacing(),
-                                        binaryOrPrimaryExpressionParser.ExpressionRule(),
-                                        spacingParser.Spacing(),
-                                        String("]"),
+                MapSelectionExpressionTrail()
+        );
+    }
 
-                                        push(new MapSelectionExpression(positionTrackerParser.pop(1), binaryOrPrimaryExpressionParser.pop(1), binaryOrPrimaryExpressionParser.pop()))
-                                ),
-                                parserContext().parser(BinaryOperationSuffixExpressionParser.class).ExpressionRule()
-                        )
+    public Rule MapSelectionExpressionTrail() {
+        BinaryOrPrimaryExpressionParser binaryOrPrimaryExpressionParser = parserContext().parser(BinaryOrPrimaryExpressionParser.class);
+        PositionTrackerParser positionTrackerParser = parserContext().parser(PositionTrackerParser.class);
+        SpacingParser spacingParser = parserContext().parser(SpacingParser.class);
+
+        return ZeroOrMore(
+                FirstOf(
+                        Sequence(
+                                positionTrackerParser.PushPosition(),
+                                String("["), spacingParser.Spacing(),
+                                binaryOrPrimaryExpressionParser.ExpressionRule(),
+                                spacingParser.Spacing(),
+                                String("]"),
+
+                                push(new MapSelectionExpression(positionTrackerParser.pop(1), binaryOrPrimaryExpressionParser.pop(1), binaryOrPrimaryExpressionParser.pop()))
+                        ),
+                        parserContext().parser(BinaryOperationSuffixExpressionParser.class).ExpressionRule()
                 )
         );
     }

--- a/src/main/java/org/jtwig/parser/parboiled/expression/SimpleExpressionParser.java
+++ b/src/main/java/org/jtwig/parser/parboiled/expression/SimpleExpressionParser.java
@@ -3,6 +3,7 @@ package org.jtwig.parser.parboiled.expression;
 import org.jtwig.model.expression.Expression;
 import org.jtwig.parser.parboiled.ParserContext;
 import org.parboiled.Rule;
+import org.parboiled.annotations.Label;
 
 public class SimpleExpressionParser extends ExpressionParser<Expression> {
     public SimpleExpressionParser(ParserContext context) {
@@ -10,6 +11,7 @@ public class SimpleExpressionParser extends ExpressionParser<Expression> {
     }
 
     @Override
+    @Label("Simple Expression")
     public Rule ExpressionRule() {
         return FirstOf(
                 parserContext().parser(TernaryOperationExpressionParser.class).ExpressionRule(),

--- a/src/main/java/org/jtwig/parser/parboiled/expression/TestOperationExpressionParser.java
+++ b/src/main/java/org/jtwig/parser/parboiled/expression/TestOperationExpressionParser.java
@@ -19,18 +19,18 @@ public class TestOperationExpressionParser extends ExpressionParser<TestOperatio
     @Label("Test Operation")
     public Rule ExpressionRule() {
         SpacingParser spacingParser = parserContext().parser(SpacingParser.class);
-        SimpleExpressionParser anyExpressionParser = parserContext().parser(SimpleExpressionParser.class);
+        SimpleExpressionParser simpleExpressionParser = parserContext().parser(SimpleExpressionParser.class);
         AnyTestExpressionParser testExpressionParser = parserContext().parser(AnyTestExpressionParser.class);
         PositionTrackerParser positionTrackerParser = parserContext().parser(PositionTrackerParser.class);
         return Sequence(
                 positionTrackerParser.PushPosition(),
-                anyExpressionParser.ExpressionRule(),
+                simpleExpressionParser.ExpressionRule(),
                 spacingParser.Spacing(),
                 parserContext().parser(LexicParser.class).Keyword(Keyword.IS),
                 spacingParser.Spacing(),
                 testExpressionParser.Test(),
 
-                push(new TestOperationExpression(positionTrackerParser.pop(2), anyExpressionParser.pop(1), testExpressionParser.pop()))
+                push(new TestOperationExpression(positionTrackerParser.pop(2), simpleExpressionParser.pop(1), testExpressionParser.pop()))
         );
     }
 }

--- a/src/main/java/org/jtwig/parser/parboiled/node/OutputNodeParser.java
+++ b/src/main/java/org/jtwig/parser/parboiled/node/OutputNodeParser.java
@@ -27,7 +27,7 @@ public class OutputNodeParser extends NodeParser<OutputNode> {
                 Mandatory(anyExpressionParser.ExpressionRule(), "Missing or invalid output expression"),
                 spacingParser.Spacing(),
 
-                Mandatory(limitsParser.endOutput(), "Expecting end of output code island"),
+                Mandatory(limitsParser.endOutput(), "Expecting end of output code island (Hint: Try to wrap parts of your expression in parentheses)"),
 
                 push(new OutputNode(
                         positionTrackerParser.pop(1),

--- a/src/test/java/org/jtwig/integration/expression/VariableNestedAccessTest.java
+++ b/src/test/java/org/jtwig/integration/expression/VariableNestedAccessTest.java
@@ -341,6 +341,285 @@ public class VariableNestedAccessTest {
     }
 
 
+    @Test
+    public void mapMapWithArithmeticTest() {
+        testWith("{{ map['map']['key'] + 1 - 1 }}");
+    }
+
+    @Test
+    public void mapMapDotWithArithmeticTest() {
+        testWith("{{ map['map'].key + 1 - 1 }}");
+    }
+
+    @Test
+    public void mapListWithArithmeticTest() {
+        testWith("{{ map['list'][0] + 1 - 1 }}");
+    }
+
+    @Test
+    public void mapMethodWithArithmeticTest() {
+        testWith("{{ map['object'].valueMethod() + 1 - 1 }}");
+    }
+
+    @Test
+    public void mapFieldWithArithmeticTest() {
+        testWith("{{ map['object'].value_field + 1 - 1 }}");
+    }
+
+    @Test
+    public void mapGetterWithArithmeticTest() {
+        testWith("{{ map['object'].valueGetter + 1 - 1 }}");
+    }
+
+
+    @Test
+    public void mapWithParenthesisMapWithArithmeticTest() {
+        testWith("{{ (map['map'])['key'] + 1 - 1 }}");
+    }
+
+    @Test
+    public void mapWithParenthesisMapDWithArithmeticotTest() {
+        testWith("{{ (map['map']).key + 1 - 1 }}");
+    }
+
+    @Test
+    public void mapWithParenthesisListWithArithmeticTest() {
+        testWith("{{ (map['list'])[0] + 1 - 1 }}");
+    }
+
+    @Test
+    public void mapWithParenthesisMethodWithArithmeticTest() {
+        testWith("{{ (map['object']).valueMethod() + 1 - 1 }}");
+    }
+
+    @Test
+    public void mapWithParenthesisFieldWithArithmeticTest() {
+        testWith("{{ (map['object']).value_field + 1 - 1 }}");
+    }
+
+    @Test
+    public void mapWithParenthesisGetterWithArithmeticTest() {
+        testWith("{{ (map['object']).valueGetter + 1 - 1 }}");
+    }
+
+
+    @Test
+    public void mapDotMapWithArithmeticTest() {
+        testWith("{{ map.map['key'] + 1 - 1 }}");
+    }
+
+    @Test
+    public void mapDotMapDotWithArithmeticTest() {
+        testWith("{{ map.map.key + 1 - 1 }}");
+    }
+
+    @Test
+    public void mapDotListWithArithmeticTest() {
+        testWith("{{ map.list[0] + 1 - 1 }}");
+    }
+
+    @Test
+    public void mapDotMethodWithArithmeticTest() {
+        testWith("{{ map.object.valueMethod() + 1 - 1 }}");
+    }
+
+    @Test
+    public void mapDotFieldWithArithmeticTest() {
+        testWith("{{ map.object.value_field + 1 - 1 }}");
+    }
+
+    @Test
+    public void mapDotGetterWithArithmeticTest() {
+        testWith("{{ map.object.valueGetter + 1 - 1 }}");
+    }
+
+
+    @Test
+    public void listMapWithArithmeticTest() {
+        testWith("{{ list[1]['key'] + 1 - 1 }}");
+    }
+
+    @Test
+    public void listMapDotWithArithmeticTest() {
+        testWith("{{ list[1].key + 1 - 1 }}");
+    }
+
+    @Test
+    public void listListWithArithmeticTest() {
+        testWith("{{ list[0][0] + 1 - 1 }}");
+    }
+
+    @Test
+    public void listMethodWithArithmeticTest() {
+        testWith("{{ list[2].valueMethod() + 1 - 1 }}");
+    }
+
+    @Test
+    public void listFieldWithArithmeticTest() {
+        testWith("{{ list[2].value_field + 1 - 1 }}");
+    }
+
+    @Test
+    public void listGetterWithArithmeticTest() {
+        testWith("{{ list[2].valueGetter + 1 - 1 }}");
+    }
+
+
+    @Test
+    public void listWithParenthesisMapWithArithmeticTest() {
+        testWith("{{ (list[1])['key'] + 1 - 1 }}");
+    }
+
+    @Test
+    public void listWithParenthesisWithArithmeticMapDotTest() {
+        testWith("{{ (list[1]).key + 1 - 1 }}");
+    }
+
+    @Test
+    public void listWithParenthesiWithArithmeticsListTest() {
+        testWith("{{ (list[0])[0] + 1 - 1 }}");
+    }
+
+    @Test
+    public void listWithParenthesisMethodWithArithmeticTest() {
+        testWith("{{ (list[2]).valueMethod() + 1 - 1 }}");
+    }
+
+    @Test
+    public void listWithParenthesisFieldWithArithmeticTest() {
+        testWith("{{ (list[2]).value_field + 1 - 1 }}");
+    }
+
+    @Test
+    public void listWithParenthesisGetterWithArithmeticTest() {
+        testWith("{{ (list[2]).valueGetter + 1 - 1 }}");
+    }
+
+
+    @Test
+    public void mapWithGetMapWithArithmeticTest() {
+        testWith("{{ map.get('map')['key'] + 1 - 1 }}");
+    }
+
+    @Test
+    public void mapWithGetMapDotWithArithmeticTest() {
+        testWith("{{ map.get('map').key + 1 - 1 }}");
+    }
+
+    @Test
+    public void mapWithGetListWithArithmeticTest() {
+        testWith("{{ map.get('list')[0] + 1 - 1 }}");
+    }
+
+    @Test
+    public void mapWithGetMethodWithArithmeticTest() {
+        testWith("{{ map.get('object').valueMethod() + 1 - 1 }}");
+    }
+
+    @Test
+    public void mapWithGetFieldWithArithmeticTest() {
+        testWith("{{ map.get('object').value_field + 1 - 1 }}");
+    }
+
+    @Test
+    public void mapWithGetGetterWithArithmeticTest() {
+        testWith("{{ map.get('object').valueGetter + 1 - 1 }}");
+    }
+
+
+    @Test
+    public void methodMapWithArithmeticTest() {
+        testWith("{{ object.mapMethod()['key'] + 1 - 1 }}");
+    }
+
+    @Test
+    public void methodMapDotWithArithmeticTest() {
+        testWith("{{ object.mapMethod().key + 1 - 1 }}");
+    }
+
+    @Test
+    public void methodListWithArithmeticTest() {
+        testWith("{{ object.listMethod()[0] + 1 - 1 }}");
+    }
+
+    @Test
+    public void methodMethodWithArithmeticTest() {
+        testWith("{{ object.nestedMethod().valueMethod() + 1 - 1 }}");
+    }
+
+    @Test
+    public void methodFieldWithArithmeticTest() {
+        testWith("{{ object.nestedMethod().value_field + 1 - 1 }}");
+    }
+
+    @Test
+    public void methodGetterWithArithmeticTest() {
+        testWith("{{ object.nestedMethod().valueGetter + 1 - 1 }}");
+    }
+
+
+    @Test
+    public void fieldMapWithArithmeticTest() {
+        testWith("{{ object.map_field['key'] + 1 - 1 }}");
+    }
+
+    @Test
+    public void fieldMapDotWithArithmeticTest() {
+        testWith("{{ object.map_field.key + 1 - 1 }}");
+    }
+
+    @Test
+    public void fieldListWithArithmeticTest() {
+        testWith("{{ object.list_field[0] + 1 - 1 }}");
+    }
+
+    @Test
+    public void fieldMethodWithArithmeticTest() {
+        testWith("{{ object.nested_field.valueMethod() + 1 - 1 }}");
+    }
+
+    @Test
+    public void fieldFieldWithArithmeticTest() {
+        testWith("{{ object.nested_field.value_field + 1 - 1 }}");
+    }
+
+    @Test
+    public void fieldGetterWithArithmeticTest() {
+        testWith("{{ object.nested_field.valueGetter + 1 - 1 }}");
+    }
+
+
+    @Test
+    public void getterMapWithArithmeticTest() {
+        testWith("{{ object.mapGetter['key'] + 1 - 1 }}");
+    }
+
+    @Test
+    public void getterMapDotWithArithmeticTest() {
+        testWith("{{ object.mapGetter.key + 1 - 1 }}");
+    }
+
+    @Test
+    public void getterListWithArithmeticTest() {
+        testWith("{{ object.listGetter[0] + 1 - 1 }}");
+    }
+
+    @Test
+    public void getterMethodWithArithmeticTest() {
+        testWith("{{ object.nestedGetter.valueMethod() + 1 - 1 }}");
+    }
+
+    @Test
+    public void getterFieldWithArithmeticTest() {
+        testWith("{{ object.nestedGetter.value_field + 1 - 1 }}");
+    }
+
+    @Test
+    public void getterGetterWithArithmeticTest() {
+        testWith("{{ object.nestedGetter.valueGetter + 1 - 1 }}");
+    }
+
+
     private class NestedTestClass {
         private static final int MAX_DEPTH = 2;
 

--- a/src/test/java/org/jtwig/integration/expression/VariableNestedAccessTest.java
+++ b/src/test/java/org/jtwig/integration/expression/VariableNestedAccessTest.java
@@ -94,6 +94,37 @@ public class VariableNestedAccessTest {
 
 
     @Test
+    public void mapWithParenthesisMapTest() {
+        testWith("{{ (map['map'])['key'] }}");
+    }
+
+    @Test
+    public void mapWithParenthesisMapDotTest() {
+        testWith("{{ (map['map']).key }}");
+    }
+
+    @Test
+    public void mapWithParenthesisListTest() {
+        testWith("{{ (map['list'])[0] }}");
+    }
+
+    @Test
+    public void mapWithParenthesisMethodTest() {
+        testWith("{{ (map['object']).valueMethod() }}");
+    }
+
+    @Test
+    public void mapWithParenthesisFieldTest() {
+        testWith("{{ (map['object']).value_field }}");
+    }
+
+    @Test
+    public void mapWithParenthesisGetterTest() {
+        testWith("{{ (map['object']).valueGetter }}");
+    }
+
+
+    @Test
     public void mapDotMapTest() {
         testWith("{{ map.map['key'] }}");
     }
@@ -152,6 +183,68 @@ public class VariableNestedAccessTest {
     @Test
     public void listGetterTest() {
         testWith("{{ list[2].valueGetter }}");
+    }
+
+
+    @Test
+    public void listWithParenthesisMapTest() {
+        testWith("{{ (list[1])['key'] }}");
+    }
+
+    @Test
+    public void listWithParenthesisMapDotTest() {
+        testWith("{{ (list[1]).key }}");
+    }
+
+    @Test
+    public void listWithParenthesisListTest() {
+        testWith("{{ (list[0])[0] }}");
+    }
+
+    @Test
+    public void listWithParenthesisMethodTest() {
+        testWith("{{ (list[2]).valueMethod() }}");
+    }
+
+    @Test
+    public void listWithParenthesisFieldTest() {
+        testWith("{{ (list[2]).value_field }}");
+    }
+
+    @Test
+    public void listWithParenthesisGetterTest() {
+        testWith("{{ (list[2]).valueGetter }}");
+    }
+
+
+    @Test
+    public void mapWithGetMapTest() {
+        testWith("{{ map.get('map')['key'] }}");
+    }
+
+    @Test
+    public void mapWithGetMapDotTest() {
+        testWith("{{ map.get('map').key }}");
+    }
+
+    @Test
+    public void mapWithGetListTest() {
+        testWith("{{ map.get('list')[0] }}");
+    }
+
+    @Test
+    public void mapWithGetMethodTest() {
+        testWith("{{ map.get('object').valueMethod() }}");
+    }
+
+    @Test
+    public void mapWithGetFieldTest() {
+        testWith("{{ map.get('object').value_field }}");
+    }
+
+    @Test
+    public void mapWithGetGetterTest() {
+        testWith("{{ map.get('object').valueGetter }}");
     }
 
 

--- a/src/test/java/org/jtwig/integration/expression/VariableNestedAccessTest.java
+++ b/src/test/java/org/jtwig/integration/expression/VariableNestedAccessTest.java
@@ -1,0 +1,305 @@
+package org.jtwig.integration.expression;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import org.jtwig.JtwigModel;
+import org.jtwig.JtwigTemplate;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.util.List;
+import java.util.Map;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.core.Is.is;
+
+public class VariableNestedAccessTest {
+
+    public static final int EXPECTED_VALUE = 32;
+    private NestedTestClass testobject;
+    private ImmutableMap<String, Object> testmap;
+    private ImmutableList<Object> teslist;
+
+    private void testWith(String template) {
+        JtwigModel model = JtwigModel.newModel()
+                .with("map", testmap)
+                .with("list", teslist)
+                .with("object", testobject);
+
+        String result = JtwigTemplate.inlineTemplate(template).render(model);
+
+        assertThat(result, is(String.valueOf(EXPECTED_VALUE)));
+    }
+
+    @Before
+    public void prepareTestClass() {
+        testobject = new NestedTestClass();
+    }
+
+    @Before
+    public void prepareTestMap() {
+        testmap = ImmutableMap.of(
+                "map", ImmutableMap.of(
+                        "key", EXPECTED_VALUE
+                ),
+                "list", ImmutableList.of(
+                        EXPECTED_VALUE
+                ),
+                "object", new NestedTestClass()
+        );
+    }
+
+    @Before
+    public void prepareTestList() {
+        teslist = ImmutableList.of(
+                ImmutableList.of(
+                        EXPECTED_VALUE
+                ),
+                ImmutableMap.of(
+                        "key", EXPECTED_VALUE
+                ),
+                new NestedTestClass()
+        );
+    }
+
+    @Test
+    public void mapMapTest() {
+        testWith("{{ map['map']['key'] }}");
+    }
+
+    @Test
+    public void mapMapDotTest() {
+        testWith("{{ map['map'].key }}");
+    }
+
+    @Test
+    public void mapListTest() {
+        testWith("{{ map['list'][0] }}");
+    }
+
+    @Test
+    public void mapMethodTest() {
+        testWith("{{ map['object'].valueMethod() }}");
+    }
+
+    @Test
+    public void mapFieldTest() {
+        testWith("{{ map['object'].value_field }}");
+    }
+
+    @Test
+    public void mapGetterTest() {
+        testWith("{{ map['object'].valueGetter }}");
+    }
+
+
+    @Test
+    public void mapDotMapTest() {
+        testWith("{{ map.map['key'] }}");
+    }
+
+    @Test
+    public void mapDotMapDotTest() {
+        testWith("{{ map.map.key }}");
+    }
+
+    @Test
+    public void mapDotListTest() {
+        testWith("{{ map.list[0] }}");
+    }
+
+    @Test
+    public void mapDotMethodTest() {
+        testWith("{{ map.object.valueMethod() }}");
+    }
+
+    @Test
+    public void mapDotFieldTest() {
+        testWith("{{ map.object.value_field }}");
+    }
+
+    @Test
+    public void mapDotGetterTest() {
+        testWith("{{ map.object.valueGetter }}");
+    }
+
+
+    @Test
+    public void listMapTest() {
+        testWith("{{ list[1]['key'] }}");
+    }
+
+    @Test
+    public void listMapDotTest() {
+        testWith("{{ list[1].key }}");
+    }
+
+    @Test
+    public void listListTest() {
+        testWith("{{ list[0][0] }}");
+    }
+
+    @Test
+    public void listMethodTest() {
+        testWith("{{ list[2].valueMethod() }}");
+    }
+
+    @Test
+    public void listFieldTest() {
+        testWith("{{ list[2].value_field }}");
+    }
+
+    @Test
+    public void listGetterTest() {
+        testWith("{{ list[2].valueGetter }}");
+    }
+
+
+    @Test
+    public void methodMapTest() {
+        testWith("{{ object.mapMethod()['key'] }}");
+    }
+
+    @Test
+    public void methodMapDotTest() {
+        testWith("{{ object.mapMethod().key }}");
+    }
+
+    @Test
+    public void methodListTest() {
+        testWith("{{ object.listMethod()[0] }}");
+    }
+
+    @Test
+    public void methodMethodTest() {
+        testWith("{{ object.nestedMethod().valueMethod() }}");
+    }
+
+    @Test
+    public void methodFieldTest() {
+        testWith("{{ object.nestedMethod().value_field }}");
+    }
+
+    @Test
+    public void methodGetterTest() {
+        testWith("{{ object.nestedMethod().valueGetter }}");
+    }
+
+
+    @Test
+    public void fieldMapTest() {
+        testWith("{{ object.map_field['key'] }}");
+    }
+
+    @Test
+    public void fieldMapDotTest() {
+        testWith("{{ object.map_field.key }}");
+    }
+
+    @Test
+    public void fieldListTest() {
+        testWith("{{ object.list_field[0] }}");
+    }
+
+    @Test
+    public void fieldMethodTest() {
+        testWith("{{ object.nested_field.valueMethod() }}");
+    }
+
+    @Test
+    public void fieldFieldTest() {
+        testWith("{{ object.nested_field.value_field }}");
+    }
+
+    @Test
+    public void fieldGetterTest() {
+        testWith("{{ object.nested_field.valueGetter }}");
+    }
+
+
+    @Test
+    public void getterMapTest() {
+        testWith("{{ object.mapGetter['key'] }}");
+    }
+
+    @Test
+    public void getterMapDotTest() {
+        testWith("{{ object.mapGetter.key }}");
+    }
+
+    @Test
+    public void getterListTest() {
+        testWith("{{ object.listGetter[0] }}");
+    }
+
+    @Test
+    public void getterMethodTest() {
+        testWith("{{ object.nestedGetter.valueMethod() }}");
+    }
+
+    @Test
+    public void getterFieldTest() {
+        testWith("{{ object.nestedGetter.value_field }}");
+    }
+
+    @Test
+    public void getterGetterTest() {
+        testWith("{{ object.nestedGetter.valueGetter }}");
+    }
+
+
+    private class NestedTestClass {
+        private static final int MAX_DEPTH = 2;
+
+        public final int value_field = EXPECTED_VALUE;
+        public final ImmutableMap<String, Integer> map_field = ImmutableMap.of("key", EXPECTED_VALUE);
+        public final ImmutableList<Integer> list_field = ImmutableList.of(EXPECTED_VALUE);
+        public NestedTestClass nested_field;
+
+        private NestedTestClass() {
+            this(0);
+        }
+
+        private NestedTestClass(int depth) {
+            if (depth >= MAX_DEPTH) {
+                return;
+            }
+
+            nested_field = new NestedTestClass(depth + 1);
+            ;
+        }
+
+        public NestedTestClass getNestedGetter() {
+            return nested_field;
+        }
+
+        public NestedTestClass nestedMethod() {
+            return nested_field;
+        }
+
+        public int getValueGetter() {
+            return value_field;
+        }
+
+        public int valueMethod() {
+            return value_field;
+        }
+
+        public Map<String, Integer> getMapGetter() {
+            return map_field;
+        }
+
+        public Map<String, Integer> mapMethod() {
+            return map_field;
+        }
+
+
+        public List<Integer> getListGetter() {
+            return list_field;
+        }
+
+        public List<Integer> listMethod() {
+            return list_field;
+        }
+    }
+}


### PR DESCRIPTION
This PR splits the `BinaryOperationExpressionParser` into two parts by extracting most of the logic into the `BinaryOperationSuffixExpressionParser` which matches everything after the primary expression, ie in `3 + 5 - 6` the `BinaryOperationSuffixExpressionParser` now matches ` + 5 - 6`. The `BinaryOperationExpressionParser` now matches the primary expression `3` followed by an `BinaryOperationSuffixExpressionParser`.

This is important, because Method-Calls are also modeled as Binary Operations, so in `foo.bar()` the `BinaryOperationSuffixExpressionParser` now matches `.bar()`. It can now be used to perform Method-Calls (and other arithmetic) on arbitrary Values, which is important for the next change.

Additionally the `MapSelectionExpressionParser` is extended, so that after a `MapSelectionExpression`, ie the square bracket in `map['foo']`, another one can follow (ie `map['foo']['bar']`). Also, after a `MapSelectionExpression` an optional `BinaryOperationSuffixExpressionParser` is inserted, so that expressions like `map['foo'].method()` or `map['foo'] + 5` succeed.

To verify the correct behavior across all combinations, `VariableNestedAccessTest` is introduced which uses the JUnit4 `Parameterized` Test-Runner to dynamically construct all combinations (currently 107 Tests) of Access-Patterns. A list of all Patterns currently tested is attached to this PR: [tests-2017-07-16.txt](https://github.com/jtwig/jtwig-core/files/1151099/tests-2017-07-16.txt)

this PR aims at fixing jtwig/jtwig#344, please see there for a detailed description of the Problem and some Documentation on how to mitigate it.

Thanks to @florolf for his support and insight into parser theory.