### PR TITLE
parent method

### DIFF
--- a/src/main/java/org/jtwig/functions/config/DefaultJtwigFunctionList.java
+++ b/src/main/java/org/jtwig/functions/config/DefaultJtwigFunctionList.java
@@ -14,6 +14,7 @@ import org.jtwig.functions.impl.math.RoundFunction;
 import org.jtwig.functions.impl.mixed.*;
 import org.jtwig.functions.impl.string.*;
 import org.jtwig.functions.impl.structural.BlockFunction;
+import org.jtwig.functions.impl.structural.ParentFunction;
 import org.jtwig.reflection.model.java.JavaClassManager;
 import org.jtwig.util.ClasspathFinder;
 
@@ -36,6 +37,7 @@ public class DefaultJtwigFunctionList extends ArrayList<JtwigFunction> {
 
                 // Structural
                 new BlockFunction(),
+                new ParentFunction(),
 
                 // Math
                 new AbsFunction(),

--- a/src/main/java/org/jtwig/functions/impl/structural/BlockFunction.java
+++ b/src/main/java/org/jtwig/functions/impl/structural/BlockFunction.java
@@ -19,9 +19,13 @@ public class BlockFunction extends SimpleJtwigFunction {
         request.maximumNumberOfArguments(1);
         String name = request.getEnvironment().getValueEnvironment().getStringConverter().convert(request.get(0));
 
-        Optional<BlockDefinition> blockDefinition = request.getRenderContext().getCurrent(BlockContext.class).get(name);
+        Optional<BlockDefinition> blockDefinitionOptional = request.getRenderContext().getCurrent(BlockContext.class).get(name);
+        if(!blockDefinitionOptional.isPresent()) {
+            return "";
+        }
+
         request.getRenderContext().start(BlockReference.class, new BlockReference(name));
-        Object renderable = NodeRenderHelper.renderBlock(request, blockDefinition);
+        Object renderable = NodeRenderHelper.renderBlock(request, blockDefinitionOptional.get());
         request.getRenderContext().end(BlockReference.class);
         return renderable;
     }

--- a/src/main/java/org/jtwig/functions/impl/structural/BlockFunction.java
+++ b/src/main/java/org/jtwig/functions/impl/structural/BlockFunction.java
@@ -5,6 +5,7 @@ import org.jtwig.functions.FunctionRequest;
 import org.jtwig.functions.SimpleJtwigFunction;
 import org.jtwig.render.context.model.BlockContext;
 import org.jtwig.render.context.model.BlockDefinition;
+import org.jtwig.render.context.model.BlockReference;
 
 public class BlockFunction extends SimpleJtwigFunction {
     @Override
@@ -19,6 +20,9 @@ public class BlockFunction extends SimpleJtwigFunction {
         String name = request.getEnvironment().getValueEnvironment().getStringConverter().convert(request.get(0));
 
         Optional<BlockDefinition> blockDefinition = request.getRenderContext().getCurrent(BlockContext.class).get(name);
-        return NodeRenderHelper.renderBlock(request, blockDefinition);
+        request.getRenderContext().start(BlockReference.class, new BlockReference(name));
+        Object renderable = NodeRenderHelper.renderBlock(request, blockDefinition);
+        request.getRenderContext().end(BlockReference.class);
+        return renderable;
     }
 }

--- a/src/main/java/org/jtwig/functions/impl/structural/BlockFunction.java
+++ b/src/main/java/org/jtwig/functions/impl/structural/BlockFunction.java
@@ -5,10 +5,6 @@ import org.jtwig.functions.FunctionRequest;
 import org.jtwig.functions.SimpleJtwigFunction;
 import org.jtwig.render.context.model.BlockContext;
 import org.jtwig.render.context.model.BlockDefinition;
-import org.jtwig.render.node.RenderNodeService;
-import org.jtwig.renderable.RenderResult;
-import org.jtwig.renderable.StringBuilderRenderResult;
-import org.jtwig.resource.reference.ResourceReference;
 
 public class BlockFunction extends SimpleJtwigFunction {
     @Override
@@ -22,17 +18,7 @@ public class BlockFunction extends SimpleJtwigFunction {
         request.maximumNumberOfArguments(1);
         String name = request.getEnvironment().getValueEnvironment().getStringConverter().convert(request.get(0));
 
-        Optional<BlockDefinition> nodeOptional = request.getRenderContext().getCurrent(BlockContext.class).get(name);
-        if (nodeOptional.isPresent()) {
-            RenderNodeService renderNodeService = request.getEnvironment().getRenderEnvironment().getRenderNodeService();
-            BlockDefinition definition = nodeOptional.get();
-            request.getRenderContext().start(ResourceReference.class, definition.getSource());
-            RenderResult result = renderNodeService.render(request, definition.getNode())
-                    .appendTo(new StringBuilderRenderResult());
-            request.getRenderContext().end(ResourceReference.class);
-            return result.content();
-        } else {
-            return "";
-        }
+        Optional<BlockDefinition> blockDefinition = request.getRenderContext().getCurrent(BlockContext.class).get(name);
+        return NodeRenderHelper.renderBlock(request, blockDefinition);
     }
 }

--- a/src/main/java/org/jtwig/functions/impl/structural/NodeRenderHelper.java
+++ b/src/main/java/org/jtwig/functions/impl/structural/NodeRenderHelper.java
@@ -1,6 +1,5 @@
 package org.jtwig.functions.impl.structural;
 
-import com.google.common.base.Optional;
 import org.jtwig.functions.FunctionRequest;
 import org.jtwig.render.context.model.BlockDefinition;
 import org.jtwig.render.node.RenderNodeService;
@@ -9,14 +8,6 @@ import org.jtwig.renderable.StringBuilderRenderResult;
 import org.jtwig.resource.reference.ResourceReference;
 
 class NodeRenderHelper {
-    public static Object renderBlock(FunctionRequest renderRequest, Optional<BlockDefinition> blockDefinition) {
-        if (blockDefinition.isPresent()) {
-            return renderBlock(renderRequest, blockDefinition.get());
-        } else {
-            return "";
-        }
-    }
-
     public static Object renderBlock(FunctionRequest renderRequest, BlockDefinition blockDefinition) {
         RenderNodeService renderNodeService = renderRequest.getEnvironment().getRenderEnvironment().getRenderNodeService();
         renderRequest.getRenderContext().start(ResourceReference.class, blockDefinition.getSource());

--- a/src/main/java/org/jtwig/functions/impl/structural/NodeRenderHelper.java
+++ b/src/main/java/org/jtwig/functions/impl/structural/NodeRenderHelper.java
@@ -8,7 +8,7 @@ import org.jtwig.renderable.StringBuilderRenderResult;
 import org.jtwig.resource.reference.ResourceReference;
 
 class NodeRenderHelper {
-    public static Object renderBlock(FunctionRequest renderRequest, BlockDefinition blockDefinition) {
+    static Object renderBlock(FunctionRequest renderRequest, BlockDefinition blockDefinition) {
         RenderNodeService renderNodeService = renderRequest.getEnvironment().getRenderEnvironment().getRenderNodeService();
         renderRequest.getRenderContext().start(ResourceReference.class, blockDefinition.getSource());
         RenderResult result = renderNodeService.render(renderRequest, blockDefinition.getNode())

--- a/src/main/java/org/jtwig/functions/impl/structural/NodeRenderHelper.java
+++ b/src/main/java/org/jtwig/functions/impl/structural/NodeRenderHelper.java
@@ -1,0 +1,29 @@
+package org.jtwig.functions.impl.structural;
+
+import com.google.common.base.Optional;
+import org.jtwig.functions.FunctionRequest;
+import org.jtwig.render.context.model.BlockDefinition;
+import org.jtwig.render.node.RenderNodeService;
+import org.jtwig.renderable.RenderResult;
+import org.jtwig.renderable.StringBuilderRenderResult;
+import org.jtwig.resource.reference.ResourceReference;
+
+class NodeRenderHelper {
+    public static Object renderBlock(FunctionRequest renderRequest, Optional<BlockDefinition> blockDefinition) {
+        if (blockDefinition.isPresent()) {
+            return renderBlock(renderRequest, blockDefinition.get());
+        } else {
+            return "";
+        }
+    }
+
+    public static Object renderBlock(FunctionRequest renderRequest, BlockDefinition blockDefinition) {
+        RenderNodeService renderNodeService = renderRequest.getEnvironment().getRenderEnvironment().getRenderNodeService();
+        renderRequest.getRenderContext().start(ResourceReference.class, blockDefinition.getSource());
+        RenderResult result = renderNodeService.render(renderRequest, blockDefinition.getNode())
+                .appendTo(new StringBuilderRenderResult());
+
+        renderRequest.getRenderContext().end(ResourceReference.class);
+        return result.content();
+    }
+}

--- a/src/main/java/org/jtwig/functions/impl/structural/ParentFunction.java
+++ b/src/main/java/org/jtwig/functions/impl/structural/ParentFunction.java
@@ -28,6 +28,10 @@ public class ParentFunction extends SimpleJtwigFunction {
         BlockContext blockContext = request.getRenderContext().getCurrent(BlockContext.class);
         Optional<BlockDefinition> blockDefinition = blockContext.get(blockIdentifier, 1);
 
+        if(!blockDefinition.isPresent()) {
+            throw new IllegalStateException("Call to parent() in a Block that does not extend another Block.");
+        }
+
         return NodeRenderHelper.renderBlock(request, blockDefinition);
     }
 }

--- a/src/main/java/org/jtwig/functions/impl/structural/ParentFunction.java
+++ b/src/main/java/org/jtwig/functions/impl/structural/ParentFunction.java
@@ -42,7 +42,7 @@ public class ParentFunction extends SimpleJtwigFunction {
             throw new ParentFunctionOutsideBlockException();
         }
 
-        Optional<BlockDefinition> currentBlockDefinition = blockContext.pop(identifier);
+        Optional<BlockDefinition> currentBlockDefinition = blockContext.pollFirst(identifier);
         //System.err.println("parent function in block "+currentBlockDefinition.get().getSource());
 
         if(!currentBlockDefinition.isPresent()) {
@@ -58,7 +58,7 @@ public class ParentFunction extends SimpleJtwigFunction {
         }
 
         Object renderBlock = NodeRenderHelper.renderBlock(request, blockDefinition);
-        blockContext.addTop(identifier, currentBlockDefinition.get());
+        blockContext.addFirst(identifier, currentBlockDefinition.get());
 
         return renderBlock;
     }

--- a/src/main/java/org/jtwig/functions/impl/structural/ParentFunction.java
+++ b/src/main/java/org/jtwig/functions/impl/structural/ParentFunction.java
@@ -1,0 +1,19 @@
+package org.jtwig.functions.impl.structural;
+
+import org.jtwig.functions.FunctionRequest;
+import org.jtwig.functions.SimpleJtwigFunction;
+
+public class ParentFunction extends SimpleJtwigFunction {
+    @Override
+    public String name() {
+        return "parent";
+    }
+
+    @Override
+    public Object execute(FunctionRequest request) {
+        request.minimumNumberOfArguments(0);
+        request.maximumNumberOfArguments(0);
+
+        return '';
+    }
+}

--- a/src/main/java/org/jtwig/functions/impl/structural/ParentFunction.java
+++ b/src/main/java/org/jtwig/functions/impl/structural/ParentFunction.java
@@ -1,7 +1,13 @@
 package org.jtwig.functions.impl.structural;
 
+import com.google.common.base.Optional;
+import org.jtwig.environment.Environment;
 import org.jtwig.functions.FunctionRequest;
 import org.jtwig.functions.SimpleJtwigFunction;
+import org.jtwig.render.context.RenderContext;
+import org.jtwig.render.context.model.BlockContext;
+import org.jtwig.render.context.model.BlockDefinition;
+import org.jtwig.render.context.model.BlockReference;
 
 public class ParentFunction extends SimpleJtwigFunction {
     @Override
@@ -14,6 +20,14 @@ public class ParentFunction extends SimpleJtwigFunction {
         request.minimumNumberOfArguments(0);
         request.maximumNumberOfArguments(0);
 
-        return '';
+        Environment env = request.getEnvironment();
+        RenderContext ctx = request.getRenderContext();
+
+        String blockIdentifier = ctx.getCurrent(BlockReference.class).getIdentifier();
+
+        BlockContext blockContext = request.getRenderContext().getCurrent(BlockContext.class);
+        Optional<BlockDefinition> blockDefinition = blockContext.get(blockIdentifier, 1);
+
+        return NodeRenderHelper.renderBlock(request, blockDefinition);
     }
 }

--- a/src/main/java/org/jtwig/functions/impl/structural/exceptions/ParentFunctionOutsideBlockException.java
+++ b/src/main/java/org/jtwig/functions/impl/structural/exceptions/ParentFunctionOutsideBlockException.java
@@ -1,0 +1,7 @@
+package org.jtwig.functions.impl.structural.exceptions;
+
+public class ParentFunctionOutsideBlockException extends IllegalStateException {
+    public ParentFunctionOutsideBlockException() {
+        super("Call to parent() when not in a block.");
+    }
+}

--- a/src/main/java/org/jtwig/functions/impl/structural/exceptions/ParentFunctionWithoutExtending.java
+++ b/src/main/java/org/jtwig/functions/impl/structural/exceptions/ParentFunctionWithoutExtending.java
@@ -1,0 +1,7 @@
+package org.jtwig.functions.impl.structural.exceptions;
+
+public class ParentFunctionWithoutExtending extends IllegalStateException {
+    public ParentFunctionWithoutExtending() {
+        super("Call to parent() in a template that does not extend another template.");
+    }
+}

--- a/src/main/java/org/jtwig/render/context/model/BlockContext.java
+++ b/src/main/java/org/jtwig/render/context/model/BlockContext.java
@@ -6,25 +6,42 @@ import org.jtwig.resource.reference.ResourceReference;
 
 import java.util.HashMap;
 import java.util.Map;
+import java.util.Stack;
 
 public class BlockContext {
-    public static BlockContext newContext () {
-        return new BlockContext(new HashMap<String, BlockDefinition>());
-    }
+    private final Map<String, Stack<BlockDefinition>> blocks;
 
-    private final Map<String, BlockDefinition> blocks;
-
-    public BlockContext(Map<String, BlockDefinition> blocks) {
+    public BlockContext(Map<String, Stack<BlockDefinition>> blocks) {
         this.blocks = blocks;
     }
 
+    public static BlockContext newContext() {
+        return new BlockContext(new HashMap<String, Stack<BlockDefinition>>());
+    }
+
     public Optional<BlockDefinition> get(String identifier) {
-        return Optional.fromNullable(blocks.get(identifier));
+        Stack<BlockDefinition> blockDefinitions = blocks.get(identifier);
+        if (blockDefinitions == null) {
+            return Optional.absent();
+        }
+
+        return Optional.fromNullable(blockDefinitions.get(0));
+    }
+
+    public Optional<BlockDefinition> get(String identifier, int index) {
+        Stack<BlockDefinition> stack = blocks.get(identifier);
+        return Optional.fromNullable(stack.get(index));
     }
 
     public void add(BlockNode node, ResourceReference source) {
+        BlockDefinition blockDefinition = new BlockDefinition(node.getContent(), source);
+
         if (!blocks.containsKey(node.getIdentifier())) {
-            blocks.put(node.getIdentifier(), new BlockDefinition(node.getContent(), source));
+            Stack<BlockDefinition> blockDefinitions = new Stack<>();
+            blockDefinitions.push(blockDefinition);
+            blocks.put(node.getIdentifier(), blockDefinitions);
+        } else {
+            blocks.get(node.getIdentifier()).push(blockDefinition);
         }
     }
 

--- a/src/main/java/org/jtwig/render/context/model/BlockContext.java
+++ b/src/main/java/org/jtwig/render/context/model/BlockContext.java
@@ -4,6 +4,7 @@ import com.google.common.base.Optional;
 import org.jtwig.model.tree.BlockNode;
 import org.jtwig.resource.reference.ResourceReference;
 
+import java.util.EmptyStackException;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Stack;
@@ -11,6 +12,7 @@ import java.util.Stack;
 public class BlockContext {
     private final Map<String, Stack<BlockDefinition>> blocks;
 
+    // FIXME cleanup heavy mis-use of the stack… analyze actual usage
     public BlockContext(Map<String, Stack<BlockDefinition>> blocks) {
         this.blocks = blocks;
     }
@@ -20,16 +22,15 @@ public class BlockContext {
     }
 
     public Optional<BlockDefinition> get(String identifier) {
-        Stack<BlockDefinition> blockDefinitions = blocks.get(identifier);
-        if (blockDefinitions == null) {
-            return Optional.absent();
-        }
-
-        return Optional.fromNullable(blockDefinitions.get(0));
+        return get(identifier, 0);
     }
 
     public Optional<BlockDefinition> get(String identifier, int index) {
         Stack<BlockDefinition> stack = blocks.get(identifier);
+        if(stack == null) {
+            return Optional.absent();
+        }
+
         try {
             return Optional.of(stack.get(index));
         } catch (ArrayIndexOutOfBoundsException e) {
@@ -39,14 +40,45 @@ public class BlockContext {
 
     public void add(BlockNode node, ResourceReference source) {
         BlockDefinition blockDefinition = new BlockDefinition(node.getContent(), source);
+        String identifier = node.getIdentifier();
 
-        if (!blocks.containsKey(node.getIdentifier())) {
+        add(identifier, blockDefinition);
+    }
+
+    public void add(String identifier, BlockDefinition blockDefinition) {
+        if (!blocks.containsKey(identifier)) {
             Stack<BlockDefinition> blockDefinitions = new Stack<>();
             blockDefinitions.push(blockDefinition);
-            blocks.put(node.getIdentifier(), blockDefinitions);
+            blocks.put(identifier, blockDefinitions);
         } else {
-            blocks.get(node.getIdentifier()).push(blockDefinition);
+            blocks.get(identifier).push(blockDefinition);
         }
     }
 
+    public Optional<BlockDefinition> pop(String identifier) {
+        Stack<BlockDefinition> stack = blocks.get(identifier);
+        if(stack == null) {
+            return Optional.absent();
+        }
+
+
+        try {
+            BlockDefinition blockDefinition = stack.get(0);
+            stack.removeElementAt(0);
+            return Optional.of(blockDefinition);
+        }
+        catch (EmptyStackException e) {
+            return Optional.absent();
+        }
+    }
+
+    public void addTop(String identifier, BlockDefinition blockDefinition) {
+        if (!blocks.containsKey(identifier)) {
+            Stack<BlockDefinition> blockDefinitions = new Stack<>();
+            blockDefinitions.add(0, blockDefinition);
+            blocks.put(identifier, blockDefinitions);
+        } else {
+            blocks.get(identifier).add(0, blockDefinition);
+        }
+    }
 }

--- a/src/main/java/org/jtwig/render/context/model/BlockContext.java
+++ b/src/main/java/org/jtwig/render/context/model/BlockContext.java
@@ -30,7 +30,11 @@ public class BlockContext {
 
     public Optional<BlockDefinition> get(String identifier, int index) {
         Stack<BlockDefinition> stack = blocks.get(identifier);
-        return Optional.fromNullable(stack.get(index));
+        try {
+            return Optional.of(stack.get(index));
+        } catch (ArrayIndexOutOfBoundsException e) {
+            return Optional.absent();
+        }
     }
 
     public void add(BlockNode node, ResourceReference source) {

--- a/src/main/java/org/jtwig/render/context/model/BlockReference.java
+++ b/src/main/java/org/jtwig/render/context/model/BlockReference.java
@@ -1,0 +1,18 @@
+package org.jtwig.render.context.model;
+
+public class BlockReference {
+    private String identifier;
+
+    public BlockReference(String identifier) {
+        this.identifier = identifier;
+    }
+
+    public String getIdentifier() {
+        return identifier;
+    }
+
+    public BlockReference setIdentifier(String identifier) {
+        this.identifier = identifier;
+        return this;
+    }
+}

--- a/src/main/java/org/jtwig/render/context/model/BlockReference.java
+++ b/src/main/java/org/jtwig/render/context/model/BlockReference.java
@@ -10,9 +10,4 @@ public class BlockReference {
     public String getIdentifier() {
         return identifier;
     }
-
-    public BlockReference setIdentifier(String identifier) {
-        this.identifier = identifier;
-        return this;
-    }
 }

--- a/src/main/java/org/jtwig/render/node/renderer/BlockNodeRender.java
+++ b/src/main/java/org/jtwig/render/node/renderer/BlockNodeRender.java
@@ -4,6 +4,7 @@ import org.jtwig.model.tree.BlockNode;
 import org.jtwig.render.RenderRequest;
 import org.jtwig.render.context.model.BlockContext;
 import org.jtwig.render.context.model.BlockDefinition;
+import org.jtwig.render.context.model.BlockReference;
 import org.jtwig.render.node.RenderNodeService;
 import org.jtwig.renderable.Renderable;
 import org.jtwig.resource.reference.ResourceReference;
@@ -18,7 +19,9 @@ public class BlockNodeRender implements NodeRender<BlockNode> {
         RenderNodeService renderNodeService = renderRequest.getEnvironment().getRenderEnvironment().getRenderNodeService();
 
         renderRequest.getRenderContext().start(ResourceReference.class, definition.getSource());
+        renderRequest.getRenderContext().start(BlockReference.class, new BlockReference(identifier));
         Renderable render = renderNodeService.render(renderRequest, definition.getNode());
+        renderRequest.getRenderContext().end(BlockReference.class);
         renderRequest.getRenderContext().end(ResourceReference.class);
         return render;
     }

--- a/src/main/java/org/jtwig/render/node/renderer/BlockNodeRender.java
+++ b/src/main/java/org/jtwig/render/node/renderer/BlockNodeRender.java
@@ -14,7 +14,7 @@ public class BlockNodeRender implements NodeRender<BlockNode> {
     public Renderable render(RenderRequest renderRequest, BlockNode node) {
         String identifier = node.getIdentifier();
         ResourceReference current = renderRequest.getRenderContext().getCurrent(ResourceReference.class);
-        renderRequest.getRenderContext().getCurrent(BlockContext.class).add(node, current);
+        renderRequest.getRenderContext().getCurrent(BlockContext.class).addLast(node, current);
         BlockDefinition definition = renderRequest.getRenderContext().getCurrent(BlockContext.class).get(identifier).get();
         RenderNodeService renderNodeService = renderRequest.getEnvironment().getRenderEnvironment().getRenderNodeService();
 

--- a/src/main/java/org/jtwig/render/node/renderer/OverrideBlockNodeRender.java
+++ b/src/main/java/org/jtwig/render/node/renderer/OverrideBlockNodeRender.java
@@ -11,7 +11,7 @@ public class OverrideBlockNodeRender implements NodeRender<OverrideBlockNode> {
     @Override
     public Renderable render(RenderRequest renderRequest, OverrideBlockNode node) {
         ResourceReference current = renderRequest.getRenderContext().getCurrent(ResourceReference.class);
-        renderRequest.getRenderContext().getCurrent(BlockContext.class).add(node, current);
+        renderRequest.getRenderContext().getCurrent(BlockContext.class).addLast(node, current);
         return EmptyRenderable.instance();
     }
 }

--- a/src/test/java/org/jtwig/functions/impl/ParentFunctionTest.java
+++ b/src/test/java/org/jtwig/functions/impl/ParentFunctionTest.java
@@ -33,9 +33,15 @@ public class ParentFunctionTest {
                         "{% block a %}B{{ parent() }}B{% endblock %}")
                 .build());
 
+        TypedResourceLoader templateResourceC = new TypedResourceLoader(MEMORY, InMemoryResourceLoader.builder()
+                .withResource("c", "{% extends 'memory:b' %}" +
+                        "{% block a %}C{{ parent() }}C{% endblock %}")
+                .build());
+
         configTemplate = configuration().resources().resourceLoaders()
                 .add(templateResourceA)
                 .add(templateResourceB)
+                .add(templateResourceC)
                 .and().and().build();
     }
 
@@ -82,11 +88,20 @@ public class ParentFunctionTest {
     }
 
     @Test
-    public void inheritsParentBlockThroughMultipleLevels() {
+    public void inheritsParentBlockThroughTwoLevels() {
         testWith(
                 "{% extends 'memory:b' %}" +
                         "{% block a %}C{{ parent() }}C{% endblock %}",
                 "cCBABCx"
+        );
+    }
+
+    @Test
+    public void inheritsParentBlockThroughThreeLevels() {
+        testWith(
+                "{% extends 'memory:c' %}" +
+                        "{% block a %}D{{ parent() }}D{% endblock %}",
+                "cDCBABCDx"
         );
     }
 

--- a/src/test/java/org/jtwig/functions/impl/ParentFunctionTest.java
+++ b/src/test/java/org/jtwig/functions/impl/ParentFunctionTest.java
@@ -44,10 +44,16 @@ public class ParentFunctionTest {
                         "{% block a %}C{{ parent() }}{{ cVar }}{{ parent() }}C{% endblock %}")
                 .build());
 
+        TypedResourceLoader templateResourceWithBlockFunction = new TypedResourceLoader(MEMORY, InMemoryResourceLoader.builder()
+                .withResource("withblockfn", "<title>{% block title %}Title{% endblock %}</title>" +
+                        "{% block body %}<h1>{{ block('title') }}{% endblock %}</h1>")
+                .build());
+
         configTemplate = configuration().resources().resourceLoaders()
                 .add(templateResourceA)
                 .add(templateResourceB)
                 .add(templateResourceC)
+                .add(templateResourceWithBlockFunction)
                 .and().and().build();
     }
 
@@ -164,6 +170,15 @@ public class ParentFunctionTest {
                         "{% block a %}C{{ parent() }}C{% endblock %}" +
                         "{% block z %}Z{{ block('a')}}Z{% endblock %}",
                 "xCBABCxZCBABCZ"
+        );
+    }
+
+    @Test
+    public void blockFunctionInParentTemplateReferencesCurrentBlock() {
+        testWith(
+                "{% extends 'memory:withblockfn' %}" +
+                        "{% block title %}Subtitle - {{ parent() }}{% endblock %}",
+                "<title>Subtitle - Title</title><h1>Subtitle - Title</h1>"
         );
     }
 }

--- a/src/test/java/org/jtwig/functions/impl/ParentFunctionTest.java
+++ b/src/test/java/org/jtwig/functions/impl/ParentFunctionTest.java
@@ -27,7 +27,7 @@ public class ParentFunctionTest {
     @Before
     public void setupConfiguration() {
         TypedResourceLoader templateResourceA = new TypedResourceLoader(MEMORY, InMemoryResourceLoader.builder()
-                .withResource("a", "x{% block a %}A{% endblock %}x")
+                .withResource("a", "x{% block a %}A{% endblock %}x{% block z %}{% endblock %}")
                 .build());
 
         TypedResourceLoader templateResourceB = new TypedResourceLoader(MEMORY, InMemoryResourceLoader.builder()

--- a/src/test/java/org/jtwig/functions/impl/ParentFunctionTest.java
+++ b/src/test/java/org/jtwig/functions/impl/ParentFunctionTest.java
@@ -68,7 +68,7 @@ public class ParentFunctionTest {
     public void errorWhenCallingParentWithoutExtending() {
         testWith(
                 "{% block a %}B{{ parent() }}{% endblock %}",
-                "xBABx"
+                ""
         );
     }
 

--- a/src/test/java/org/jtwig/functions/impl/ParentFunctionTest.java
+++ b/src/test/java/org/jtwig/functions/impl/ParentFunctionTest.java
@@ -64,8 +64,7 @@ public class ParentFunctionTest {
         );
     }
 
-    // FIXME add expected exception class
-    @Test
+    @Test(expected = IllegalStateException.class)
     public void errorWhenCallingParentWithoutExtending() {
         testWith(
                 "{% block a %}B{{ parent() }}{% endblock %}",

--- a/src/test/java/org/jtwig/functions/impl/ParentFunctionTest.java
+++ b/src/test/java/org/jtwig/functions/impl/ParentFunctionTest.java
@@ -1,0 +1,123 @@
+package org.jtwig.functions.impl;
+
+import org.jtwig.JtwigModel;
+import org.jtwig.JtwigTemplate;
+import org.jtwig.environment.EnvironmentConfiguration;
+import org.jtwig.resource.loader.InMemoryResourceLoader;
+import org.jtwig.resource.loader.TypedResourceLoader;
+import org.junit.Before;
+import org.junit.Test;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.core.Is.is;
+import static org.jtwig.environment.EnvironmentConfigurationBuilder.configuration;
+import static org.jtwig.resource.reference.ResourceReference.MEMORY;
+
+public class ParentFunctionTest {
+    private JtwigModel model;
+    private EnvironmentConfiguration configTemplate;
+
+    @Before
+    public void setupModel() {
+        model = JtwigModel.newModel();
+    }
+
+    @Before
+    public void setupConfiguration() {
+        TypedResourceLoader templateResourceA = new TypedResourceLoader(MEMORY, InMemoryResourceLoader.builder()
+                .withResource("a", "x{% block a %}A{% endblock %}x")
+                .build());
+
+        TypedResourceLoader templateResourceB = new TypedResourceLoader(MEMORY, InMemoryResourceLoader.builder()
+                .withResource("b", "{% extends 'memory:a' %}" +
+                        "{% block a %}B{{ parent() }}B{% endblock %}")
+                .build());
+
+        configTemplate = configuration().resources().resourceLoaders()
+                .add(templateResourceA)
+                .add(templateResourceB)
+                .and().and().build();
+    }
+
+    private void testWith(String template, String expected) {
+        String result = JtwigTemplate.inlineTemplate(template, configTemplate)
+                .render(JtwigModel.newModel());
+
+        assertThat(result, is(expected));
+    }
+
+    @Test
+    public void inheritsParentBlock() {
+        testWith(
+                "{% extends 'memory:a' %}" +
+                        "{% block a %}B{{ parent() }}{% endblock %}",
+                "xBAx"
+        );
+    }
+
+    @Test
+    public void inheritsParentBlockWithSuffix() {
+        testWith(
+                "{% extends 'memory:a' %}" +
+                        "{% block a %}B{{ parent() }}B{% endblock %}",
+                "xBABx"
+        );
+    }
+
+    // FIXME add expected exception class
+    @Test
+    public void errorWhenCallingParentWithoutExtending() {
+        testWith(
+                "{% block a %}B{{ parent() }}{% endblock %}",
+                "xBABx"
+        );
+    }
+
+    @Test
+    public void inheritsParentBlockTwiceIfRequested() {
+        testWith(
+                "{% extends 'memory:a' %}" +
+                        "{% block a %}{{ parent() }}B{{ parent() }}{% endblock %}",
+                "xABAx"
+        );
+    }
+
+    @Test
+    public void inheritsParentBlockThroughMultipleLevels() {
+        testWith(
+                "{% extends 'memory:b' %}" +
+                        "{% block a %}C{{ parent() }}C{% endblock %}",
+                "cCBABCx"
+        );
+    }
+
+    @Test
+    public void blockFunctionInterpretsInheritedBlocks() {
+        testWith(
+                "{% extends 'memory:a' %}" +
+                        "{% block a %}{{ parent() }}B{{ parent() }}{% endblock %}" +
+                        "{% block z %}Z{{ block('a')}}Z{% endblock %}",
+                "xABAxZABAZ"
+        );
+    }
+
+    @Test
+    public void blockFunctionInterpretsInheritedBlocksIndependentOfOrder() {
+        testWith(
+                "{% extends 'memory:a' %}" +
+                        "{% block z %}Z{{ block('a')}}Z{% endblock %}" +
+                        "{% block a %}{{ parent() }}B{{ parent() }}{% endblock %}",
+                "xABAxZABAZ"
+        );
+    }
+
+    @Test
+    public void blockFunctionInterpretsInheritedBlocksThroughMultipleLevels() {
+        testWith(
+                "{% extends 'memory:b' %}" +
+                        "{% block a %}C{{ parent() }}C{% endblock %}" +
+                        "{% block z %}Z{{ block('a')}}Z{% endblock %}",
+                "xCBABCxZCBABCZ"
+        );
+    }
+}

--- a/src/test/java/org/jtwig/functions/impl/ParentFunctionTest.java
+++ b/src/test/java/org/jtwig/functions/impl/ParentFunctionTest.java
@@ -21,23 +21,27 @@ public class ParentFunctionTest {
 
     @Before
     public void setupModel() {
-        model = JtwigModel.newModel();
+        model = JtwigModel.newModel()
+                .with("aVar", "A")
+                .with("bVar", "B")
+                .with("cVar", "C")
+                .with("zVar", "Z");
     }
 
     @Before
     public void setupConfiguration() {
         TypedResourceLoader templateResourceA = new TypedResourceLoader(MEMORY, InMemoryResourceLoader.builder()
-                .withResource("a", "x{% block a %}A{% endblock %}x{% block z %}{% endblock %}")
+                .withResource("a", "x{% block a %}{{ aVar }}{% endblock %}x{% block z %}{% endblock %}")
                 .build());
 
         TypedResourceLoader templateResourceB = new TypedResourceLoader(MEMORY, InMemoryResourceLoader.builder()
                 .withResource("b", "{% extends 'memory:a' %}" +
-                        "{% block a %}B{{ parent() }}B{% endblock %}")
+                        "{% block a %}{{ bVar }}{{ parent() }}B{% endblock %}")
                 .build());
 
         TypedResourceLoader templateResourceC = new TypedResourceLoader(MEMORY, InMemoryResourceLoader.builder()
                 .withResource("c", "{% extends 'memory:b' %}" +
-                        "{% block a %}C{{ parent() }}C{{ parent() }}C{% endblock %}")
+                        "{% block a %}C{{ parent() }}{{ cVar }}{{ parent() }}C{% endblock %}")
                 .build());
 
         configTemplate = configuration().resources().resourceLoaders()
@@ -49,7 +53,7 @@ public class ParentFunctionTest {
 
     private void testWith(String template, String expected) {
         String result = JtwigTemplate.inlineTemplate(template, configTemplate)
-                .render(JtwigModel.newModel());
+                .render(model);
 
         assertThat(result, is(expected));
     }
@@ -58,7 +62,7 @@ public class ParentFunctionTest {
     public void inheritsParentBlock() {
         testWith(
                 "{% extends 'memory:a' %}" +
-                        "{% block a %}B{{ parent() }}{% endblock %}",
+                        "{% block a %}{{ bVar }}{{ parent() }}{% endblock %}",
                 "xBAx"
         );
     }
@@ -67,7 +71,7 @@ public class ParentFunctionTest {
     public void inheritsParentBlockWithSuffix() {
         testWith(
                 "{% extends 'memory:a' %}" +
-                        "{% block a %}B{{ parent() }}B{% endblock %}",
+                        "{% block a %}{{ bVar }}{{ parent() }}B{% endblock %}",
                 "xBABx"
         );
     }

--- a/src/test/java/org/jtwig/functions/impl/structural/ParentFunctionExceptionTest.java
+++ b/src/test/java/org/jtwig/functions/impl/structural/ParentFunctionExceptionTest.java
@@ -1,0 +1,73 @@
+package org.jtwig.functions.impl.structural;
+
+import com.google.common.base.Optional;
+import org.jtwig.functions.FunctionRequest;
+import org.jtwig.functions.impl.structural.exceptions.ParentFunctionOutsideBlockException;
+import org.jtwig.functions.impl.structural.exceptions.ParentFunctionWithoutExtending;
+import org.jtwig.render.context.model.BlockContext;
+import org.jtwig.render.context.model.BlockDefinition;
+import org.jtwig.render.context.model.BlockReference;
+import org.junit.Before;
+import org.junit.Test;
+
+import static org.mockito.Mockito.*;
+
+public class ParentFunctionExceptionTest {
+
+    private ParentFunction underTest;
+    private FunctionRequest request;
+
+    @Before
+    public void prepareTestdata() {
+        request = mock(FunctionRequest.class, RETURNS_DEEP_STUBS);
+        underTest = new ParentFunction();
+    }
+    @Test(expected = ParentFunctionOutsideBlockException.class)
+    public void getBlockIdentifierThrowsCorrectExceptionWhenOutsideOfBlock() {
+        when(request.getRenderContext().getCurrent(BlockReference.class)).thenThrow(IllegalStateException.class);
+
+        underTest.execute(request);
+    }
+
+    @Test(expected = ParentFunctionOutsideBlockException.class)
+    public void getBlockContextThrowsCorrectExceptionWhenOutsideOfBlock() {
+        BlockReference blockReferenceMock = mock(BlockReference.class);
+        when(blockReferenceMock.getIdentifier()).thenReturn("ident");
+
+        when(request.getRenderContext().getCurrent(BlockReference.class)).thenReturn(blockReferenceMock);
+        when(request.getRenderContext().getCurrent(BlockContext.class)).thenThrow(IllegalStateException.class);
+
+        underTest.execute(request);
+    }
+
+    @Test(expected = ParentFunctionWithoutExtending.class)
+    public void getParentBlockDefinitionThrowsCorrectExceptionWhenOutsideOfBlock() {
+        BlockReference blockReferenceMock = mock(BlockReference.class);
+        when(blockReferenceMock.getIdentifier()).thenReturn("ident");
+
+        BlockDefinition blockDefinitionMock = mock(BlockDefinition.class);
+
+        BlockContext blockContextMock = mock(BlockContext.class);
+        when(blockContextMock.pollFirst(anyString())).thenReturn(Optional.of(blockDefinitionMock));
+        when(blockContextMock.get(anyString())).thenReturn(Optional.<BlockDefinition>absent());
+
+        when(request.getRenderContext().getCurrent(BlockReference.class)).thenReturn(blockReferenceMock);
+        when(request.getRenderContext().getCurrent(BlockContext.class)).thenReturn(blockContextMock);
+
+        underTest.execute(request);
+    }
+
+    @Test(expected = ParentFunctionOutsideBlockException.class)
+    public void pollCurrentBlockDefinitionThrowsCorrectExceptionWhenOutsideOfBlock() {
+        BlockReference blockReferenceMock = mock(BlockReference.class);
+        when(blockReferenceMock.getIdentifier()).thenReturn("ident");
+
+        BlockContext blockContextMock = mock(BlockContext.class);
+        when(blockContextMock.pollFirst(anyString())).thenReturn(Optional.<BlockDefinition>absent());
+
+        when(request.getRenderContext().getCurrent(BlockReference.class)).thenReturn(blockReferenceMock);
+        when(request.getRenderContext().getCurrent(BlockContext.class)).thenReturn(blockContextMock);
+
+        underTest.execute(request);
+    }
+}

--- a/src/test/java/org/jtwig/render/context/model/BlockContextTest.java
+++ b/src/test/java/org/jtwig/render/context/model/BlockContextTest.java
@@ -9,9 +9,10 @@ import org.junit.Test;
 import org.mockito.internal.matchers.apachecommons.ReflectionEquals;
 
 import java.util.HashMap;
-import java.util.Stack;
+import java.util.LinkedList;
 
 import static org.hamcrest.core.Is.is;
+import static org.hamcrest.Matchers.notNullValue;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertThat;
 import static org.mockito.Mockito.mock;
@@ -19,7 +20,7 @@ import static org.mockito.Mockito.when;
 
 public class BlockContextTest {
     private static final String IDENTIFIER = "identifier";
-    private final HashMap<String, Stack<BlockDefinition>> map = new HashMap<>();
+    private final HashMap<String, LinkedList<BlockDefinition>> map = new HashMap<>();
     private BlockContext underTest = new BlockContext(map);
 
     private BlockNode blockNode1;
@@ -30,8 +31,8 @@ public class BlockContextTest {
     private BlockDefinition blockDefinition2;
     private ResourceReference resourceReference2;
 
-    private Stack<BlockDefinition> blockDefinitionsWithNode;
-    private Stack<BlockDefinition> blockDefinitionsWithBothNodes;
+    private LinkedList<BlockDefinition> blockDefinitionsWithNode;
+    private LinkedList<BlockDefinition> blockDefinitionsWithBothNodes;
 
     @Before
     public void prepareTestdata() {
@@ -61,12 +62,18 @@ public class BlockContextTest {
     }
 
     private void prepareTeststack() {
-        blockDefinitionsWithNode = new Stack<>();
-        blockDefinitionsWithNode.push(blockDefinition1);
+        blockDefinitionsWithNode = new LinkedList<>();
+        blockDefinitionsWithNode.add(blockDefinition1);
 
-        blockDefinitionsWithBothNodes = new Stack<>();
-        blockDefinitionsWithBothNodes.push(blockDefinition1);
-        blockDefinitionsWithBothNodes.push(blockDefinition2);
+        blockDefinitionsWithBothNodes = new LinkedList<>();
+        blockDefinitionsWithBothNodes.add(blockDefinition1);
+        blockDefinitionsWithBothNodes.add(blockDefinition2);
+    }
+
+    @Test
+    public void newContext() {
+        BlockContext blockContext = BlockContext.newContext();
+        assertThat(blockContext, notNullValue());
     }
 
     @Test
@@ -91,41 +98,61 @@ public class BlockContextTest {
     }
 
     @Test
-    public void add() throws Exception {
-        underTest.add(blockNode1, resourceReference1);
+    public void addLast() throws Exception {
+        underTest.addLast(blockNode1, resourceReference1);
 
         assertThat(map.get(IDENTIFIER).peek(), new ReflectionEquals(blockDefinition1));
     }
 
     @Test
-    public void addMultiple() throws Exception {
-        underTest.add(blockNode1, resourceReference1);
-        underTest.add(blockNode2, resourceReference2);
+    public void addLastMultiple() throws Exception {
+        underTest.addLast(blockNode1, resourceReference1);
+        underTest.addLast(blockNode2, resourceReference2);
 
         assertThat(map.get(IDENTIFIER).get(0), new ReflectionEquals(blockDefinition1));
         assertThat(map.get(IDENTIFIER).get(1), new ReflectionEquals(blockDefinition2));
     }
 
     @Test
+    public void addLastFirst() throws Exception {
+        underTest.addFirst(blockNode1, resourceReference1);
+
+        assertThat(map.get(IDENTIFIER).peek(), new ReflectionEquals(blockDefinition1));
+    }
+
+    @Test
+    public void addFirstMultiple() throws Exception {
+        underTest.addFirst(blockNode1, resourceReference1);
+        underTest.addFirst(blockNode2, resourceReference2);
+
+        assertThat(map.get(IDENTIFIER).get(1), new ReflectionEquals(blockDefinition1));
+        assertThat(map.get(IDENTIFIER).get(0), new ReflectionEquals(blockDefinition2));
+    }
+
+    @Test
     public void get() {
         map.put(IDENTIFIER, blockDefinitionsWithNode);
 
-        assertThat(underTest.get(IDENTIFIER).isPresent(), is(true));
-        assertThat(underTest.get(IDENTIFIER).get(), new ReflectionEquals(blockDefinition1));
+        Optional<BlockDefinition> definitionA = underTest.get(IDENTIFIER);
+        assertThat(definitionA.isPresent(), is(true));
+        assertThat(definitionA.get(), new ReflectionEquals(blockDefinition1));
 
-        assertThat(underTest.get(IDENTIFIER, 0).isPresent(), is(true));
-        assertThat(underTest.get(IDENTIFIER, 0).get(), new ReflectionEquals(blockDefinition1));
+        Optional<BlockDefinition> definitionB = underTest.get(IDENTIFIER, 0);
+        assertThat(definitionB.isPresent(), is(true));
+        assertThat(definitionB.get(), new ReflectionEquals(blockDefinition1));
     }
 
     @Test
     public void getMultiple() {
         map.put(IDENTIFIER, blockDefinitionsWithBothNodes);
 
-        assertThat(underTest.get(IDENTIFIER, 0).isPresent(), is(true));
-        assertThat(underTest.get(IDENTIFIER, 0).get(), new ReflectionEquals(blockDefinition1));
+        Optional<BlockDefinition> definition1 = underTest.get(IDENTIFIER, 0);
+        assertThat(definition1.isPresent(), is(true));
+        assertThat(definition1.get(), new ReflectionEquals(blockDefinition1));
 
-        assertThat(underTest.get(IDENTIFIER, 1).isPresent(), is(true));
-        assertThat(underTest.get(IDENTIFIER, 1).get(), new ReflectionEquals(blockDefinition2));
+        Optional<BlockDefinition> definition2 = underTest.get(IDENTIFIER, 1);
+        assertThat(definition2.isPresent(), is(true));
+        assertThat(definition2.get(), new ReflectionEquals(blockDefinition2));
     }
 
     @Test
@@ -138,5 +165,49 @@ public class BlockContextTest {
         map.put(IDENTIFIER, blockDefinitionsWithNode);
 
         assertThat(underTest.get(IDENTIFIER, 45).isPresent(), is(false));
+    }
+
+    @Test
+    public void pollFirst() {
+        map.put(IDENTIFIER, blockDefinitionsWithNode);
+
+        Optional<BlockDefinition> pollFirst = underTest.pollFirst(IDENTIFIER);
+        assertThat(pollFirst.isPresent(), is(true));
+        assertThat(pollFirst.get(), new ReflectionEquals(blockDefinition1));
+
+        assertThat(map.get(IDENTIFIER).size(), is(0));
+    }
+
+    @Test
+    public void pollFirstUnknownIdentifierIsAbsent() {
+        Optional<BlockDefinition> pollFirst = underTest.pollFirst(IDENTIFIER);
+        assertThat(pollFirst.isPresent(), is(false));
+    }
+
+    @Test
+    public void pollFirstOnEmptyListIsAbsent() {
+        map.put(IDENTIFIER, new LinkedList<BlockDefinition>());
+
+        Optional<BlockDefinition> pollFirst = underTest.pollFirst(IDENTIFIER);
+        assertThat(pollFirst.isPresent(), is(false));
+    }
+
+    @Test
+    public void pollFirstMultiple() {
+        map.put(IDENTIFIER, blockDefinitionsWithBothNodes);
+
+        assertThat(map.get(IDENTIFIER).size(), is(2));
+
+        Optional<BlockDefinition> definition1 = underTest.pollFirst(IDENTIFIER);
+        assertThat(definition1.isPresent(), is(true));
+        assertThat(definition1.get(), new ReflectionEquals(blockDefinition1));
+
+        assertThat(map.get(IDENTIFIER).size(), is(1));
+
+        Optional<BlockDefinition> definition2 = underTest.pollFirst(IDENTIFIER);
+        assertThat(definition2.isPresent(), is(true));
+        assertThat(definition2.get(), new ReflectionEquals(blockDefinition2));
+
+        assertThat(map.get(IDENTIFIER).size(), is(0));
     }
 }

--- a/src/test/java/org/jtwig/render/context/model/BlockContextTest.java
+++ b/src/test/java/org/jtwig/render/context/model/BlockContextTest.java
@@ -8,14 +8,16 @@ import org.junit.Test;
 import org.mockito.internal.matchers.apachecommons.ReflectionEquals;
 
 import java.util.HashMap;
+import java.util.Stack;
 
+import static org.hamcrest.core.Is.is;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertThat;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 public class BlockContextTest {
-    private final HashMap<String, BlockDefinition> map = new HashMap<>();
+    private final HashMap<String, Stack<BlockDefinition>> map = new HashMap<>();
     private BlockContext underTest = new BlockContext(map);
 
     @Test
@@ -32,7 +34,9 @@ public class BlockContextTest {
         String identifier = "identifier";
         BlockDefinition node = mock(BlockDefinition.class);
 
-        map.put(identifier, node);
+        Stack<BlockDefinition> blockDefinitions = new Stack<>();
+        blockDefinitions.push(node);
+        map.put(identifier, blockDefinitions);
 
         Optional<BlockDefinition> result = underTest.get(identifier);
 
@@ -52,6 +56,35 @@ public class BlockContextTest {
 
         underTest.add(blockNode, resourceReference);
 
-        assertThat(map.get(identifier), new ReflectionEquals(new BlockDefinition(node, resourceReference)));
+        assertThat(map.get(identifier).peek(), new ReflectionEquals(new BlockDefinition(node, resourceReference)));
+    }
+
+    @Test
+    public void addMultiple() throws Exception {
+        String identifier = "identifier";
+        Node node = mock(Node.class, "node");
+        BlockNode blockNode = mock(BlockNode.class, "block");
+        ResourceReference resourceReference = mock(ResourceReference.class, "res");
+
+        when(blockNode.getIdentifier()).thenReturn(identifier);
+        when(blockNode.getContent()).thenReturn(node);
+
+        Node node2 = mock(Node.class, "node2");
+        BlockNode blockNode2 = mock(BlockNode.class, "block2");
+        ResourceReference resourceReference2 = mock(ResourceReference.class, "res2");
+
+        when(blockNode2.getIdentifier()).thenReturn(identifier);
+        when(blockNode2.getContent()).thenReturn(node2);
+
+        underTest.add(blockNode, resourceReference);
+        underTest.add(blockNode2, resourceReference2);
+
+        assertThat(map.get(identifier).get(0), new ReflectionEquals(new BlockDefinition(node, resourceReference)));
+        assertThat(underTest.get(identifier).isPresent(), is(true));
+        assertThat(underTest.get(identifier).get(), new ReflectionEquals(new BlockDefinition(node, resourceReference)));
+
+        assertThat(map.get(identifier).get(1), new ReflectionEquals(new BlockDefinition(node2, resourceReference2)));
+        assertThat(underTest.get(identifier, 1).isPresent(), is(true));
+        assertThat(underTest.get(identifier, 1).get(), new ReflectionEquals(new BlockDefinition(node2, resourceReference2)));
     }
 }

--- a/src/test/java/org/jtwig/render/node/renderer/BlockNodeRenderTest.java
+++ b/src/test/java/org/jtwig/render/node/renderer/BlockNodeRenderTest.java
@@ -36,6 +36,6 @@ public class BlockNodeRenderTest {
         Renderable result = underTest.render(request, node);
 
         assertSame(renderable, result);
-        verify(request.getRenderContext().getCurrent(BlockContext.class)).add(node, reference);
+        verify(request.getRenderContext().getCurrent(BlockContext.class)).addLast(node, reference);
     }
 }


### PR DESCRIPTION
Implement the missing `parent()`-Method by
- adding a new `BlockReference`-Context to the `RenderContext`, which references to the current Block
- modifying the block-renderer and the block-function to maintain the `BlockReference`-Context
- extending the `BlockContext` so it maintains a `LinkedList` of all Versions of a Block, sorted by Inheritance-Level
- using the new List of `BlockContext`s and the Block-Name acquired from the new `BlockReference`-Context to render the Parent-Block and include it as the result of the new `parent()`-Function

this PR aims at fixing jtwig/jtwig#60.