### PR TITLE
Adds template fallback functionality for 'include', 'extends', and 'e…

### DIFF
--- a/src/main/java/org/jtwig/render/node/renderer/EmbedNodeRender.java
+++ b/src/main/java/org/jtwig/render/node/renderer/EmbedNodeRender.java
@@ -27,7 +27,8 @@ public class EmbedNodeRender implements NodeRender<EmbedNode> {
         Object path = calculateExpressionService.calculate(renderRequest, node.getResourceExpression());
         ResourceReference current = renderRequest.getRenderContext().getCurrent(ResourceReference.class);
         ResourceService resourceService = environment.getResourceEnvironment().getResourceService();
-        ResourceReference newReference = resourceService.resolve(current, getString(renderRequest, path));
+
+        ResourceReference newReference = resourceService.resolve(current, path, environment.getValueEnvironment());
         ResourceMetadata resourceMetadata = resourceService.loadMetadata(newReference);
 
         if (resourceMetadata.exists()) {
@@ -54,9 +55,5 @@ public class EmbedNodeRender implements NodeRender<EmbedNode> {
                 throw new ResourceNotFoundException(ErrorMessageFormatter.errorMessage(node.getPosition(), String.format("Resource '%s' not found", path)));
             }
         }
-    }
-
-    private String getString(RenderRequest request, Object input) {
-        return request.getEnvironment().getValueEnvironment().getStringConverter().convert(input);
     }
 }

--- a/src/main/java/org/jtwig/render/node/renderer/EmbedNodeRender.java
+++ b/src/main/java/org/jtwig/render/node/renderer/EmbedNodeRender.java
@@ -29,6 +29,7 @@ public class EmbedNodeRender implements NodeRender<EmbedNode> {
         ResourceService resourceService = environment.getResourceEnvironment().getResourceService();
 
         ResourceReference newReference = resourceService.resolve(current, path, environment.getValueEnvironment());
+
         ResourceMetadata resourceMetadata = resourceService.loadMetadata(newReference);
 
         if (resourceMetadata.exists()) {
@@ -56,4 +57,5 @@ public class EmbedNodeRender implements NodeRender<EmbedNode> {
             }
         }
     }
+
 }

--- a/src/main/java/org/jtwig/render/node/renderer/IncludeNodeRender.java
+++ b/src/main/java/org/jtwig/render/node/renderer/IncludeNodeRender.java
@@ -25,8 +25,8 @@ public class IncludeNodeRender implements NodeRender<IncludeNode> {
 
         Object path = calculateExpressionService.calculate(renderRequest, node.getResourceExpression());
         ResourceReference current = renderRequest.getRenderContext().getCurrent(ResourceReference.class);
-        String relativePath = environment.getValueEnvironment().getStringConverter().convert(path);
-        ResourceReference newReference = resourceService.resolve(current, relativePath);
+
+        ResourceReference newReference = resourceService.resolve(current, path, environment.getValueEnvironment());
         ResourceMetadata resourceMetadata = resourceService.loadMetadata(newReference);
 
         if (resourceMetadata.exists()) {

--- a/src/main/java/org/jtwig/resource/ResourceService.java
+++ b/src/main/java/org/jtwig/resource/ResourceService.java
@@ -10,6 +10,7 @@ import org.jtwig.resource.metadata.ResourceResourceMetadata;
 import org.jtwig.resource.reference.ResourceReference;
 import org.jtwig.resource.reference.ResourceReferenceExtractor;
 import org.jtwig.resource.resolver.RelativeResourceResolver;
+import org.jtwig.value.environment.ValueEnvironment;
 
 import java.util.Collection;
 import java.util.List;
@@ -28,6 +29,28 @@ public class ResourceService {
         this.absoluteResourceTypes = absoluteResourceTypes;
         this.relativeResourceResolvers = relativeResourceResolvers;
         this.resourceReferenceExtractor = resourceReferenceExtractor;
+    }
+
+    public ResourceReference resolve(ResourceReference current, Object path, ValueEnvironment valueEnvironment) {
+        ResourceReference resourceReference = null;
+
+        if(path instanceof List) {
+            for(Object relativePath : (List) path) {
+                ResourceReference newReference = resolve(current, valueEnvironment.getStringConverter().convert(relativePath));
+                ResourceMetadata resourceMetadata = loadMetadata(newReference);
+
+                if(resourceMetadata.exists()) {
+                    resourceReference = newReference;
+                    break;
+                }
+            }
+        }
+
+        if(resourceReference == null) {
+            resourceReference = resolve(current, valueEnvironment.getStringConverter().convert(path));
+        }
+
+        return resourceReference;
     }
 
     public ResourceReference resolve(ResourceReference current, String path) {

--- a/src/main/java/org/jtwig/resource/ResourceService.java
+++ b/src/main/java/org/jtwig/resource/ResourceService.java
@@ -34,8 +34,19 @@ public class ResourceService {
     public ResourceReference resolve(ResourceReference current, Object path, ValueEnvironment valueEnvironment) {
         ResourceReference resourceReference = null;
 
-        if(path instanceof List) {
-            for(Object relativePath : (List) path) {
+        if(path instanceof Iterable) {
+            for(Object relativePath : (Iterable) path) {
+                ResourceReference newReference = resolve(current, valueEnvironment.getStringConverter().convert(relativePath));
+                ResourceMetadata resourceMetadata = loadMetadata(newReference);
+
+                if(resourceMetadata.exists()) {
+                    resourceReference = newReference;
+                    break;
+                }
+            }
+        }
+        else if(path.getClass().isArray()) {
+            for(Object relativePath : (Object[]) path) {
                 ResourceReference newReference = resolve(current, valueEnvironment.getStringConverter().convert(relativePath));
                 ResourceMetadata resourceMetadata = loadMetadata(newReference);
 

--- a/src/test/java/org/jtwig/integration/node/EmbedTest.java
+++ b/src/test/java/org/jtwig/integration/node/EmbedTest.java
@@ -100,4 +100,35 @@ public class EmbedTest extends AbstractIntegrationTest {
         JtwigTemplate.inlineTemplate("{% embed 'asdasd' %}")
                 .render(JtwigModel.newModel());
     }
+
+    @Test
+    public void embedFallbacks() throws Exception {
+        JtwigTemplate template = JtwigTemplate.inlineTemplate("{% embed ['memory:b', 'memory:a'] %}{% endembed %}", configuration()
+                .resources().resourceLoaders().add(new TypedResourceLoader(MEMORY, InMemoryResourceLoader
+                        .builder()
+                        .withResource("a", "{% block one %}{{ 'a' }}{% endblock %}")
+                        .build())).and().and()
+                .build()
+        );
+
+        String result = template.render(JtwigModel.newModel());
+
+        assertThat(result, is("a"));
+    }
+
+    @Test
+    public void embedFirstAvailableOfFallbacks() throws Exception {
+        JtwigTemplate template = JtwigTemplate.inlineTemplate("{% embed ['memory:b', 'memory:a'] %}{% endembed %}", configuration()
+                .resources().resourceLoaders().add(new TypedResourceLoader(MEMORY, InMemoryResourceLoader
+                        .builder()
+                        .withResource("a", "{% block one %}{{ 'a' }}{% endblock %}")
+                        .withResource("b", "{% block one %}{{ 'b' }}{% endblock %}")
+                        .build())).and().and()
+                .build()
+        );
+
+        String result = template.render(JtwigModel.newModel());
+
+        assertThat(result, is("b"));
+    }
 }

--- a/src/test/java/org/jtwig/integration/node/EmbedTest.java
+++ b/src/test/java/org/jtwig/integration/node/EmbedTest.java
@@ -11,11 +11,16 @@ import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
 
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.core.Is.is;
-import static org.hamcrest.core.StringContains.containsString;
-import static org.jtwig.environment.EnvironmentConfigurationBuilder.configuration;
-import static org.jtwig.resource.reference.ResourceReference.MEMORY;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import static org.hamcrest.MatcherAssert.*;
+import static org.hamcrest.core.Is.*;
+import static org.hamcrest.core.StringContains.*;
+import static org.jtwig.environment.EnvironmentConfigurationBuilder.*;
+import static org.jtwig.resource.reference.ResourceReference.*;
 
 public class EmbedTest extends AbstractIntegrationTest {
     @Rule
@@ -128,6 +133,48 @@ public class EmbedTest extends AbstractIntegrationTest {
         );
 
         String result = template.render(JtwigModel.newModel());
+
+        assertThat(result, is("b"));
+    }
+
+    @Test
+    public void embedFirstAvailableOfFallbacksFromIterableModel() throws Exception {
+        JtwigTemplate template = JtwigTemplate.inlineTemplate("{% embed paths %}{% endembed %}", configuration()
+                .resources().resourceLoaders().add(new TypedResourceLoader(MEMORY, InMemoryResourceLoader
+                        .builder()
+                        .withResource("a", "{% block one %}{{ 'a' }}{% endblock %}")
+                        .withResource("b", "{% block one %}{{ 'b' }}{% endblock %}")
+                        .build())).and().and()
+                .build()
+        );
+
+        List<String> pathList = new ArrayList<>();
+        pathList.add("memory:b");
+        pathList.add("memory:a");
+
+        Map<String, Object> modelData = new HashMap<>();
+        modelData.put("paths", pathList);
+
+        String result = template.render(JtwigModel.newModel(modelData));
+
+        assertThat(result, is("b"));
+    }
+
+    @Test
+    public void embedFirstAvailableOfFallbacksFromArrayModel() throws Exception {
+        JtwigTemplate template = JtwigTemplate.inlineTemplate("{% embed paths %}{% endembed %}", configuration()
+                .resources().resourceLoaders().add(new TypedResourceLoader(MEMORY, InMemoryResourceLoader
+                        .builder()
+                        .withResource("a", "{% block one %}{{ 'a' }}{% endblock %}")
+                        .withResource("b", "{% block one %}{{ 'b' }}{% endblock %}")
+                        .build())).and().and()
+                .build()
+        );
+
+        Map<String, Object> modelData = new HashMap<>();
+        modelData.put("paths", new String[] {"memory:b", "memory:a"});
+
+        String result = template.render(JtwigModel.newModel(modelData));
 
         assertThat(result, is("b"));
     }

--- a/src/test/java/org/jtwig/integration/node/ExtendsTest.java
+++ b/src/test/java/org/jtwig/integration/node/ExtendsTest.java
@@ -11,12 +11,17 @@ import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
 
-import static java.util.Arrays.asList;
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.core.Is.is;
-import static org.hamcrest.core.StringContains.containsString;
-import static org.jtwig.environment.EnvironmentConfigurationBuilder.configuration;
-import static org.jtwig.resource.reference.ResourceReference.MEMORY;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import static java.util.Arrays.*;
+import static org.hamcrest.MatcherAssert.*;
+import static org.hamcrest.core.Is.*;
+import static org.hamcrest.core.StringContains.*;
+import static org.jtwig.environment.EnvironmentConfigurationBuilder.*;
+import static org.jtwig.resource.reference.ResourceReference.*;
 
 public class ExtendsTest extends AbstractIntegrationTest {
     @Rule
@@ -192,6 +197,48 @@ public class ExtendsTest extends AbstractIntegrationTest {
         );
 
         String result = template.render(JtwigModel.newModel());
+
+        assertThat(result, is("b"));
+    }
+
+    @Test
+    public void extendFirstAvailableOfFallbacksFromIterableModel() throws Exception {
+        JtwigTemplate template = JtwigTemplate.inlineTemplate("{% extends paths %}", configuration()
+                .resources().resourceLoaders().add(new TypedResourceLoader(MEMORY, InMemoryResourceLoader
+                        .builder()
+                        .withResource("a", "{% block one %}{{ 'a' }}{% endblock %}")
+                        .withResource("b", "{% block one %}{{ 'b' }}{% endblock %}")
+                        .build())).and().and()
+                .build()
+        );
+
+        List<String> pathList = new ArrayList<>();
+        pathList.add("memory:b");
+        pathList.add("memory:a");
+
+        Map<String, Object> modelData = new HashMap<>();
+        modelData.put("paths", pathList);
+
+        String result = template.render(JtwigModel.newModel(modelData));
+
+        assertThat(result, is("b"));
+    }
+
+    @Test
+    public void extendFirstAvailableOfFallbacksFromArrayModel() throws Exception {
+        JtwigTemplate template = JtwigTemplate.inlineTemplate("{% extends paths %}", configuration()
+                .resources().resourceLoaders().add(new TypedResourceLoader(MEMORY, InMemoryResourceLoader
+                        .builder()
+                        .withResource("a", "{% block one %}{{ 'a' }}{% endblock %}")
+                        .withResource("b", "{% block one %}{{ 'b' }}{% endblock %}")
+                        .build())).and().and()
+                .build()
+        );
+
+        Map<String, Object> modelData = new HashMap<>();
+        modelData.put("paths", new String[] {"memory:b", "memory:a"});
+
+        String result = template.render(JtwigModel.newModel(modelData));
 
         assertThat(result, is("b"));
     }

--- a/src/test/java/org/jtwig/integration/node/ExtendsTest.java
+++ b/src/test/java/org/jtwig/integration/node/ExtendsTest.java
@@ -164,4 +164,35 @@ public class ExtendsTest extends AbstractIntegrationTest {
             return title;
         }
     }
+
+    @Test
+    public void extendFallbacks() throws Exception {
+        JtwigTemplate template = JtwigTemplate.inlineTemplate("{% extends ['memory:b', 'memory:a'] %}", configuration()
+                .resources().resourceLoaders().add(new TypedResourceLoader(MEMORY, InMemoryResourceLoader
+                        .builder()
+                        .withResource("a", "{% block one %}{{ 'a' }}{% endblock %}")
+                        .build())).and().and()
+                .build()
+        );
+
+        String result = template.render(JtwigModel.newModel());
+
+        assertThat(result, is("a"));
+    }
+
+    @Test
+    public void extendFirstAvailableOfFallbacks() throws Exception {
+        JtwigTemplate template = JtwigTemplate.inlineTemplate("{% extends ['memory:b', 'memory:a'] %}", configuration()
+                .resources().resourceLoaders().add(new TypedResourceLoader(MEMORY, InMemoryResourceLoader
+                        .builder()
+                        .withResource("a", "{% block one %}{{ 'a' }}{% endblock %}")
+                        .withResource("b", "{% block one %}{{ 'b' }}{% endblock %}")
+                        .build())).and().and()
+                .build()
+        );
+
+        String result = template.render(JtwigModel.newModel());
+
+        assertThat(result, is("b"));
+    }
 }

--- a/src/test/java/org/jtwig/integration/node/IncludeTest.java
+++ b/src/test/java/org/jtwig/integration/node/IncludeTest.java
@@ -178,4 +178,35 @@ public class IncludeTest extends AbstractIntegrationTest {
 
         template.render(newModel());
     }
+
+    @Test
+    public void includeFallbacks() throws Exception {
+        JtwigTemplate template = JtwigTemplate.inlineTemplate("{% include ['memory:b', 'memory:a'] %}", configuration()
+                .resources().resourceLoaders().add(new TypedResourceLoader(MEMORY, InMemoryResourceLoader
+                        .builder()
+                        .withResource("a", "{{ 'a' }}")
+                        .build())).and().and()
+                .build()
+        );
+
+        String result = template.render(newModel());
+
+        assertThat(result, is("a"));
+    }
+
+    @Test
+    public void includingFirstAvailableOfFallbacks() throws Exception {
+        JtwigTemplate template = JtwigTemplate.inlineTemplate("{% include ['memory:b', 'memory:a'] %}", configuration()
+                .resources().resourceLoaders().add(new TypedResourceLoader(MEMORY, InMemoryResourceLoader
+                        .builder()
+                        .withResource("a", "{{ 'a' }}")
+                        .withResource("b", "{{ 'b' }}")
+                        .build())).and().and()
+                .build()
+        );
+
+        String result = template.render(newModel());
+
+        assertThat(result, is("b"));
+    }
 }

--- a/src/test/java/org/jtwig/integration/node/IncludeTest.java
+++ b/src/test/java/org/jtwig/integration/node/IncludeTest.java
@@ -11,12 +11,17 @@ import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
 
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.core.Is.is;
-import static org.hamcrest.core.StringContains.containsString;
-import static org.jtwig.JtwigModel.newModel;
-import static org.jtwig.environment.EnvironmentConfigurationBuilder.configuration;
-import static org.jtwig.resource.reference.ResourceReference.MEMORY;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import static org.hamcrest.MatcherAssert.*;
+import static org.hamcrest.core.Is.*;
+import static org.hamcrest.core.StringContains.*;
+import static org.jtwig.JtwigModel.*;
+import static org.jtwig.environment.EnvironmentConfigurationBuilder.*;
+import static org.jtwig.resource.reference.ResourceReference.*;
 
 public class IncludeTest extends AbstractIntegrationTest {
     @Rule
@@ -206,6 +211,48 @@ public class IncludeTest extends AbstractIntegrationTest {
         );
 
         String result = template.render(newModel());
+
+        assertThat(result, is("b"));
+    }
+
+    @Test
+    public void includingFirstAvailableOfFallbacksFromIterableModel() throws Exception {
+        JtwigTemplate template = JtwigTemplate.inlineTemplate("{% include paths %}", configuration()
+                .resources().resourceLoaders().add(new TypedResourceLoader(MEMORY, InMemoryResourceLoader
+                        .builder()
+                        .withResource("a", "{{ 'a' }}")
+                        .withResource("b", "{{ 'b' }}")
+                        .build())).and().and()
+                .build()
+        );
+
+        List<String> pathList = new ArrayList<>();
+        pathList.add("memory:b");
+        pathList.add("memory:a");
+
+        Map<String, Object> modelData = new HashMap<>();
+        modelData.put("paths", pathList);
+
+        String result = template.render(JtwigModel.newModel(modelData));
+
+        assertThat(result, is("b"));
+    }
+
+    @Test
+    public void includingFirstAvailableOfFallbacksFromArrayModel() throws Exception {
+        JtwigTemplate template = JtwigTemplate.inlineTemplate("{% include paths %}", configuration()
+                .resources().resourceLoaders().add(new TypedResourceLoader(MEMORY, InMemoryResourceLoader
+                        .builder()
+                        .withResource("a", "{{ 'a' }}")
+                        .withResource("b", "{{ 'b' }}")
+                        .build())).and().and()
+                .build()
+        );
+
+        Map<String, Object> modelData = new HashMap<>();
+        modelData.put("paths", new String[] {"memory:b", "memory:a"});
+
+        String result = template.render(JtwigModel.newModel(modelData));
 
         assertThat(result, is("b"));
     }

--- a/src/test/java/org/jtwig/render/node/renderer/EmbedNodeRenderTest.java
+++ b/src/test/java/org/jtwig/render/node/renderer/EmbedNodeRenderTest.java
@@ -18,12 +18,10 @@ import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
 
-import static java.util.Arrays.asList;
-import static org.hamcrest.CoreMatchers.containsString;
-import static org.hamcrest.CoreMatchers.is;
-import static org.jtwig.support.MatcherUtils.theSame;
-import static org.junit.Assert.assertSame;
-import static org.junit.Assert.assertThat;
+import static java.util.Arrays.*;
+import static org.hamcrest.CoreMatchers.*;
+import static org.jtwig.support.MatcherUtils.*;
+import static org.junit.Assert.*;
 import static org.mockito.Matchers.argThat;
 import static org.mockito.Matchers.eq;
 import static org.mockito.Mockito.*;
@@ -116,7 +114,7 @@ public class EmbedNodeRenderTest {
         when(request.getRenderContext().getCurrent(ResourceReference.class)).thenReturn(resource);
         when(environment.getValueEnvironment().getStringConverter().convert(pathExpressionValue)).thenReturn(pathExpressionValueAsString);
         when(environment.getRenderEnvironment().getCalculateExpressionService()).thenReturn(calculateExpressionService);
-        when(environment.getResourceEnvironment().getResourceService().resolve(resource, pathExpressionValueAsString)).thenReturn(newResource);
+        when(environment.getResourceEnvironment().getResourceService().resolve(resource, pathExpressionValue, environment.getValueEnvironment())).thenReturn(newResource);
         when(calculateExpressionService.calculate(request, pathExpression)).thenReturn(pathExpressionValue);
         when(calculateExpressionService.calculate(request, mapExpression)).thenReturn(mapExpressionValue);
         when(environment.getValueEnvironment().getCollectionConverter().convert(mapExpressionValue)).thenReturn(Converter.Result.defined(wrappedCollection));
@@ -161,7 +159,7 @@ public class EmbedNodeRenderTest {
         when(request.getRenderContext().getCurrent(ResourceReference.class)).thenReturn(resource);
         when(environment.getValueEnvironment().getStringConverter().convert(pathExpressionValue)).thenReturn(pathExpressionValueAsString);
         when(environment.getRenderEnvironment().getCalculateExpressionService()).thenReturn(calculateExpressionService);
-        when(environment.getResourceEnvironment().getResourceService().resolve(resource, pathExpressionValueAsString)).thenReturn(newResource);
+        when(environment.getResourceEnvironment().getResourceService().resolve(resource, pathExpressionValue, environment.getValueEnvironment())).thenReturn(newResource);
         when(calculateExpressionService.calculate(request, pathExpression)).thenReturn(pathExpressionValue);
         when(calculateExpressionService.calculate(request, mapExpression)).thenReturn(mapExpressionValue);
         when(environment.getValueEnvironment().getCollectionConverter().convert(mapExpressionValue)).thenReturn(Converter.Result.defined(wrappedCollection));

--- a/src/test/java/org/jtwig/render/node/renderer/ExtendsNodeRenderTest.java
+++ b/src/test/java/org/jtwig/render/node/renderer/ExtendsNodeRenderTest.java
@@ -78,7 +78,7 @@ public class ExtendsNodeRenderTest {
         when(node.getNodes()).thenReturn(asList(node1, node2));
         when(environment.getRenderEnvironment().getCalculateExpressionService().calculate(request, expression)).thenReturn(pathValue);
         when(environment.getValueEnvironment().getStringConverter().convert(pathValue)).thenReturn(path);
-        when(environment.getResourceEnvironment().getResourceService().resolve(parentResource, path)).thenReturn(newResource);
+        when(environment.getResourceEnvironment().getResourceService().resolve(parentResource, pathValue, environment.getValueEnvironment())).thenReturn(newResource);
         when(environment.getRenderEnvironment().getRenderResourceService().render(eq(request), argThat(theSame(new RenderResourceRequest(newResource, false, false, WrappedCollection.empty()))))).thenReturn(renderable);
         when(environment.getResourceEnvironment().getResourceService().loadMetadata(newResource)).thenReturn(resourceMetadata);
         when(resourceMetadata.exists()).thenReturn(true);

--- a/src/test/java/org/jtwig/render/node/renderer/IncludeNodeRenderTest.java
+++ b/src/test/java/org/jtwig/render/node/renderer/IncludeNodeRenderTest.java
@@ -99,7 +99,7 @@ public class IncludeNodeRenderTest {
         when(environment.getRenderEnvironment().getCalculateExpressionService().calculate(request, resourceExpression)).thenReturn(path);
         when(request.getRenderContext().getCurrent(ResourceReference.class)).thenReturn(currentResource);
         when(environment.getValueEnvironment().getStringConverter().convert(path)).thenReturn(relativePath);
-        when(environment.getResourceEnvironment().getResourceService().resolve(currentResource, relativePath)).thenReturn(resource);
+        when(environment.getResourceEnvironment().getResourceService().resolve(currentResource, path, environment.getValueEnvironment())).thenReturn(resource);
         when(environment.getRenderEnvironment().getCalculateExpressionService().calculate(request, mapExpression)).thenReturn(mapValue);
         when(environment.getValueEnvironment().getCollectionConverter().convert(mapValue)).thenReturn(Converter.Result.defined(empty));
         when(environment.getRenderEnvironment().getRenderResourceService().render(eq(request), argThat(theSame(new RenderResourceRequest(resource, true, !inherit, empty))))).thenReturn(renderable);

--- a/src/test/java/org/jtwig/resource/ResourceServiceTest.java
+++ b/src/test/java/org/jtwig/resource/ResourceServiceTest.java
@@ -4,9 +4,12 @@ import com.google.common.base.Optional;
 import org.jtwig.resource.exceptions.ResourceException;
 import org.jtwig.resource.loader.ResourceLoader;
 import org.jtwig.resource.loader.TypedResourceLoader;
+import org.jtwig.resource.metadata.ResourceMetadata;
 import org.jtwig.resource.reference.ResourceReference;
 import org.jtwig.resource.reference.ResourceReferenceExtractor;
 import org.jtwig.resource.resolver.RelativeResourceResolver;
+import org.jtwig.value.convert.string.StringConverter;
+import org.jtwig.value.environment.ValueEnvironment;
 import org.junit.Before;
 import org.junit.Test;
 
@@ -157,5 +160,52 @@ public class ResourceServiceTest {
     @Test(expected = ResourceException.class)
     public void loadMetadataNoLoader() throws Exception {
         underTest.loadMetadata(new ResourceReference("haha", "path"));
+    }
+
+    @Test
+    public void resolveGenericResourceFromString() throws Exception {
+        ResourceReference source = mock(ResourceReference.class);
+        ResourceReference reference = mock(ResourceReference.class);
+        ResourceMetadata resourceMetadata = mock(ResourceMetadata.class);
+        ValueEnvironment valueEnvironment = mock(ValueEnvironment.class);
+        StringConverter stringConverter = mock(StringConverter.class);
+
+        ResourceService underTest = mock(ResourceService.class);
+
+        when(stringConverter.convert("path")).thenReturn("path");
+        when(valueEnvironment.getStringConverter()).thenReturn(stringConverter);
+        when(resourceMetadata.exists()).thenReturn(true);
+        when(underTest.loadMetadata(reference)).thenReturn(resourceMetadata);
+        when(underTest.resolve(source, "path")).thenReturn(reference);
+        when(underTest.resolve(source, "path", valueEnvironment)).thenCallRealMethod();
+
+        ResourceReference result = underTest.resolve(source, "path", valueEnvironment);
+
+        assertSame(reference, result);
+    }
+
+    @Test
+    public void resolveGenericResourceFromList() throws Exception {
+        ResourceReference source = mock(ResourceReference.class);
+        ResourceReference reference = mock(ResourceReference.class);
+        ResourceMetadata resourceMetadata = mock(ResourceMetadata.class);
+        ValueEnvironment valueEnvironment = mock(ValueEnvironment.class);
+        StringConverter stringConverter = mock(StringConverter.class);
+
+        ResourceService underTest = mock(ResourceService.class);
+
+        List<String> pathsList = new ArrayList<>();
+        pathsList.add("path");
+
+        when(stringConverter.convert(pathsList.get(0))).thenReturn(pathsList.get(0));
+        when(valueEnvironment.getStringConverter()).thenReturn(stringConverter);
+        when(resourceMetadata.exists()).thenReturn(true);
+        when(underTest.loadMetadata(reference)).thenReturn(resourceMetadata);
+        when(underTest.resolve(source, pathsList.get(0))).thenReturn(reference);
+        when(underTest.resolve(source, pathsList, valueEnvironment)).thenCallRealMethod();
+
+        ResourceReference result = underTest.resolve(source, pathsList, valueEnvironment);
+
+        assertSame(reference, result);
     }
 }

--- a/src/test/java/org/jtwig/resource/ResourceServiceTest.java
+++ b/src/test/java/org/jtwig/resource/ResourceServiceTest.java
@@ -195,13 +195,38 @@ public class ResourceServiceTest {
         ResourceService underTest = mock(ResourceService.class);
 
         List<String> pathsList = new ArrayList<>();
-        pathsList.add("path");
+        pathsList.add("path1");
+        pathsList.add("path2");
 
         when(stringConverter.convert(pathsList.get(0))).thenReturn(pathsList.get(0));
         when(valueEnvironment.getStringConverter()).thenReturn(stringConverter);
         when(resourceMetadata.exists()).thenReturn(true);
         when(underTest.loadMetadata(reference)).thenReturn(resourceMetadata);
         when(underTest.resolve(source, pathsList.get(0))).thenReturn(reference);
+        when(underTest.resolve(source, pathsList, valueEnvironment)).thenCallRealMethod();
+
+        ResourceReference result = underTest.resolve(source, pathsList, valueEnvironment);
+
+        assertSame(reference, result);
+    }
+
+    @Test
+    public void resolveGenericResourceFromArray() throws Exception {
+        ResourceReference source = mock(ResourceReference.class);
+        ResourceReference reference = mock(ResourceReference.class);
+        ResourceMetadata resourceMetadata = mock(ResourceMetadata.class);
+        ValueEnvironment valueEnvironment = mock(ValueEnvironment.class);
+        StringConverter stringConverter = mock(StringConverter.class);
+
+        ResourceService underTest = mock(ResourceService.class);
+
+        String[] pathsList = new String[] {"path1", "path2"};
+
+        when(stringConverter.convert(pathsList[0])).thenReturn(pathsList[0]);
+        when(valueEnvironment.getStringConverter()).thenReturn(stringConverter);
+        when(resourceMetadata.exists()).thenReturn(true);
+        when(underTest.loadMetadata(reference)).thenReturn(resourceMetadata);
+        when(underTest.resolve(source, pathsList[0])).thenReturn(reference);
         when(underTest.resolve(source, pathsList, valueEnvironment)).thenCallRealMethod();
 
         ResourceReference result = underTest.resolve(source, pathsList, valueEnvironment);


### PR DESCRIPTION
Fixes issue jtwig/jtwig#327.

Adds template fallback functionality for 'include', 'extends', and 'embed' tags for PHP Twig compatibility. 

Adds new tests in `IncludeTest`, `ExtendsTest`, `EmbedTest`, and `ResourceServiceTest`. There are existing tests failing in `ExtendsNodeRenderTest`, `ExtendsNodeRenderTest`, `IncludeNodeRenderTest`, that I need some help resolving before it's ready to merge.