### PR TITLE
Add check for NPE into first and last functions

### DIFF
--- a/src/main/java/org/jtwig/functions/impl/mixed/FirstFunction.java
+++ b/src/main/java/org/jtwig/functions/impl/mixed/FirstFunction.java
@@ -20,6 +20,9 @@ public class FirstFunction extends SimpleJtwigFunction {
         request.minimumNumberOfArguments(1).maximumNumberOfArguments(1);
 
         Object input = request.get(0);
+        if (input == null) {
+            throw request.exception("Cannot get first element from a collection: input is null.");
+        }
         Converter.Result<WrappedCollection> collectionResult = request.getEnvironment()
                 .getValueEnvironment().getCollectionConverter()
                 .convert(input);

--- a/src/main/java/org/jtwig/functions/impl/mixed/LastFunction.java
+++ b/src/main/java/org/jtwig/functions/impl/mixed/LastFunction.java
@@ -20,6 +20,9 @@ public class LastFunction extends SimpleJtwigFunction {
         request.minimumNumberOfArguments(1).maximumNumberOfArguments(1);
 
         Object input = request.get(0);
+        if (input == null) {
+            throw request.exception("Cannot get last element from a collection: input is null.");
+        }
         Converter.Result<WrappedCollection> collectionResult = request.getEnvironment()
                 .getValueEnvironment().getCollectionConverter()
                 .convert(input);


### PR DESCRIPTION
Within `first` and `last` functions if input is `null`, `NullConverter` is used. Then we try to get iterator but we get NPE, which has no detailed context about its cause.