### PR TITLE
Clean ThreadLocal after render to avoid memory leaks

### DIFF
--- a/src/main/java/org/jtwig/JtwigTemplate.java
+++ b/src/main/java/org/jtwig/JtwigTemplate.java
@@ -107,5 +107,8 @@ public class JtwigTemplate {
         renderContext.end(EscapeEngine.class);
         renderContext.end(ResourceReference.class);
         renderContext.end(BlockContext.class);
+
+        EnvironmentHolder.remove();
+        RenderContextHolder.remove();
     }
 }

--- a/src/main/java/org/jtwig/environment/EnvironmentHolder.java
+++ b/src/main/java/org/jtwig/environment/EnvironmentHolder.java
@@ -11,4 +11,8 @@ public class EnvironmentHolder {
         instance.set(environment);
         return environment;
     }
+
+    public static void remove () {
+        instance.remove();
+    }
 }

--- a/src/main/java/org/jtwig/render/context/RenderContextHolder.java
+++ b/src/main/java/org/jtwig/render/context/RenderContextHolder.java
@@ -13,4 +13,8 @@ public class RenderContextHolder {
     public static RenderContext get () {
         return current.get();
     }
+
+    public static void remove () {
+        current.remove();
+    }
 }


### PR DESCRIPTION
Hello,
Thank you for your lib.
We had some trouble while redeploying context  in tomcat after integrating jtwig in our web app :
```
The web application [] created a ThreadLocal with key of type [java.lang.ThreadLocal] (value [java.lang.ThreadLocal@568af440]) and a value of type [org.jtwig.render.context.RenderContext] (value [org.jtwig.render.context.RenderContext@745ca512]) but failed to remove it when the web application was stopped. Threads are going to be renewed over time to try and avoid a probable memory leak.
sept. 06, 2017 4:42:40 PM org.apache.catalina.loader.WebappClassLoaderBase checkThreadLocalMapForLeaks
GRAVE: The web application [] created a ThreadLocal with key of type [java.lang.InheritableThreadLocal] (value [java.lang.InheritableThreadLocal@5110b039]) and a value of type [org.jtwig.environment.Environment] (value [org.jtwig.environment.Environment@5d0ce656]) but failed to remove it when the web application was stopped. Threads are going to be renewed over time to try and avoid a probable memory leak.
sept. 06, 2017 4:42:40 PM org.apache.catalina.loader.WebappClassLoaderBase checkThreadLocalMapForLeaks
```
It seems that variables initialized in ThreadLocal during template render were not dereferenced thus not garbage collected.
Here is a proposition for a fix (we tested and it resolved tomcat7 errors).