### PR TITLE
Added GlobalModel to jtwig with Test

### DIFF
--- a/src/main/java/org/jtwig/JtwigModel.java
+++ b/src/main/java/org/jtwig/JtwigModel.java
@@ -14,14 +14,35 @@ public class JtwigModel {
         }
         return model;
     }
-    public static JtwigModel newModel () {
+
+    public static JtwigModel newEmptyModel(Map<String, Object> values) {
+        JtwigModel model = newEmptyModel();
+        for (Map.Entry<String, Object> entry : values.entrySet()) {
+            model.with(entry.getKey(), entry.getValue());
+        }
+        return model;
+    }
+
+    public static JtwigModel newModel() {
         return new JtwigModel();
+    }
+
+    public static JtwigModel newEmptyModel() {
+        return new JtwigModel(false);
     }
 
     private final Map<String, Value> values;
 
+    public JtwigModel(boolean useGlobal) {
+        if (useGlobal) {
+            this.values = JtwigGlobalModel.INSTANCE.getGobalModel();
+        } else {
+            this.values = new HashMap<>();
+        }
+    }
+
     public JtwigModel() {
-        this.values = new HashMap<>();
+        this(true);
     }
 
     public JtwigModel with(String name, Object value) {
@@ -29,7 +50,7 @@ public class JtwigModel {
         return this;
     }
 
-    public Optional<Value> get (String key) {
+    public Optional<Value> get(String key) {
         return Optional.fromNullable(values.get(key));
     }
 }

--- a/src/test/java/org/jtwig/JtwigGlobalModelTest.java
+++ b/src/test/java/org/jtwig/JtwigGlobalModelTest.java
@@ -1,0 +1,52 @@
+package org.jtwig;
+
+import com.google.common.base.Optional;
+import org.jtwig.reflection.model.Value;
+import org.junit.Test;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+public class JtwigGlobalModelTest {
+    
+    @Test
+    public void putInGlobal() {
+        JtwigModel emptyModel = JtwigGlobalModel.newModel();
+        Optional<Value> testEmpty = emptyModel.get("test");
+        assertFalse("New models should not be filled", testEmpty.isPresent());
+        
+        JtwigGlobalModel.with("test", "T3ST");
+
+        JtwigModel filledModel = JtwigGlobalModel.newModel();
+        Optional<Value> testFilled = filledModel.get("test");
+        assertTrue("New models should take from global", testFilled.isPresent());
+
+        JtwigGlobalModel.remove("test");
+
+        emptyModel = JtwigGlobalModel.newModel();
+        testEmpty = emptyModel.get("test");
+        assertFalse("New models should not be filled when global is empty", testEmpty.isPresent());
+    }
+
+    @Test
+    public void modelFromGlobal() {
+        JtwigGlobalModel.with("test", "D0G3");
+
+        JtwigModel filledModel = JtwigModel.newModel();
+        Optional<Value> testFilled = filledModel.get("test");
+        assertTrue("New models should take from global", testFilled.isPresent());
+        
+        JtwigGlobalModel.remove("test");
+    }
+
+    @Test
+    public void modelNotFromGlobal() {
+        JtwigGlobalModel.with("test", "W0W");
+        
+        JtwigModel emptyModel = JtwigModel.newEmptyModel();
+        Optional<Value> testEmpty = emptyModel.get("test");
+        assertFalse("New empty models should not take from global", testEmpty.isPresent());
+
+        JtwigGlobalModel.remove("test");
+    }
+}


### PR DESCRIPTION
I got 2 ideas for this problem

With PHP version, when you add afterwards to the global, the existing models all have the 'new' value from global
since that is not java default behavior, i didn't implement it

but if you say, "we want that!"
then I add it to the pull request